### PR TITLE
UID Branch

### DIFF
--- a/src/DicomRTTool/__init__.py
+++ b/src/DicomRTTool/__init__.py
@@ -380,7 +380,9 @@ class DicomReaderWriter:
                         index = 0
                         while index in self.series_instances_dictionary:
                             index += 1
-                        self.series_instances_dictionary[index] = return_template_dictionary()
+                        temp_dict = return_template_dictionary()
+                        temp_dict['SeriesInstanceUID'] = refed_series_instance_uid
+                        self.series_instances_dictionary[index] = temp_dict
                     else:
                         index = keys[series_instance_uids.index(refed_series_instance_uid)]
                     if series_instance_uid not in self.series_instances_dictionary[index]['RTs']:

--- a/src/DicomRTTool/__init__.py
+++ b/src/DicomRTTool/__init__.py
@@ -153,6 +153,7 @@ class DicomReaderWriter:
         :param flip_axes: tuple(3), axis that you want to flip, defaults to (False, False, False)
         :param kwargs:
         """
+        self.Frames_of_Reference = {}
         self.get_dose_output = get_dose_output
         self.require_all_contours = require_all_contours
         self.flip_axes = flip_axes
@@ -442,6 +443,11 @@ class DicomReaderWriter:
     def get_images(self):
         self.dicom_handle = self.reader.Execute()
         sop_instance_UID_key = "0008|0018"
+        frame_of_ref = self.reader.GetMetaData(0, "0020|0052")
+        if frame_of_ref not in self.Frames_of_Reference.keys():
+            self.Frames_of_Reference[frame_of_ref] = {'Images': [self.PathDicom], 'RTs': []}
+        else:
+            self.Frames_of_Reference[frame_of_ref]['Images'] += [self.PathDicom]
         self.SOPInstanceUIDs = [self.reader.GetMetaData(i, sop_instance_UID_key) for i in
                                 range(self.dicom_handle.GetDepth())]
         if max(self.flip_axes):

--- a/src/DicomRTTool/__init__.py
+++ b/src/DicomRTTool/__init__.py
@@ -278,7 +278,9 @@ class DicomReaderWriter:
                 self.add_dicom_to_dictionary(root)
         if self.verbose:
             for key in self.series_instances_dictionary:
-                print('Index {}, description {}'.format(key, self.series_instances_dictionary[key]['Description']))
+                print('Index {}, description {} at {}'.format(key,
+                                                              self.series_instances_dictionary[key]['Description'],
+                                                              self.series_instances_dictionary[key]['Image_Path']))
             print('{} unique series IDs were found, to load one please use the'
                   ' read_images(index), default is 0'.format(len(self.series_instances_dictionary)))
         self.check_if_all_contours_present()
@@ -629,8 +631,8 @@ class DicomReaderWriter:
         contour_values[0] = 1  # Keep background
         prediction_array = prediction_array[..., contour_values == 1]
         contour_values = contour_values[1:]
+        not_contained = list(np.asarray(ROI_Names)[contour_values == 0])
         ROI_Names = list(np.asarray(ROI_Names)[contour_values == 1])
-        not_contained = np.asarray(ROI_Names)[contour_values == 0]
         if not_contained:
             print('RT Structure not made for ROIs {}, given prediction_array had no mask'.format(not_contained))
         self.image_size_z, self.image_size_rows, self.image_size_cols = prediction_array.shape[:3]
@@ -766,7 +768,7 @@ class DicomReaderWriter:
                 self.RS_struct.ROIContourSequence[i].ReferencedROINumber = i + 1
         if not os.path.exists(self.output_dir):
             os.makedirs(self.output_dir)
-
+        self.RS_struct.SeriesInstanceUID = pydicom.uid.generate_uid(prefix='1.2.826.0.1.3680043.8.498.')
         out_name = os.path.join(self.output_dir,
                                 'RS_MRN' + self.RS_struct.PatientID + '_' + self.RS_struct.SeriesInstanceUID + '.dcm')
         if os.path.exists(out_name):

--- a/src/DicomRTTool/__init__.py
+++ b/src/DicomRTTool/__init__.py
@@ -454,25 +454,19 @@ class DicomReaderWriter:
         print('Running off a template')
         self.change_template()
 
-    def add_sops_to_dictionary(self, sitk_dicom_reader, path):
+    def add_sops_to_dictionary(self, sitk_dicom_reader):
         """
         :param sitk_dicom_reader: sitk.ImageSeriesReader()
-        :param path: path to the images or structure in question
         """
         series_instance_uid = sitk_dicom_reader.GetMetaData(0, "0020|000e")
-        description = sitk_dicom_reader.GetMetaData(0, "0008|103e")
         self.SOPInstanceUIDs = [sitk_dicom_reader.GetMetaData(i, "0008|0018") for i in
                                 range(sitk_dicom_reader.__sizeof__())]
-        temp_dict = {'Image_Path': path, 'Description': description, 'SOP_Instance_UIDs': self.SOPInstanceUIDs}
-        if series_instance_uid not in self.series_instances_dictionary:
-            temp_dict['RTs'] = {}
-            self.series_instances_dictionary[series_instance_uid] = temp_dict
-        else:
-            self.series_instances_dictionary[series_instance_uid].update(temp_dict)
+        temp_dict = {'SOP_Instance_UIDs': self.SOPInstanceUIDs}
+        self.series_instances_dictionary[series_instance_uid].update(temp_dict)
 
     def get_images(self):
         self.dicom_handle = self.reader.Execute()
-        self.add_sops_to_dictionary(sitk_dicom_reader=self.reader, path=self.PathDicom)
+        self.add_sops_to_dictionary(sitk_dicom_reader=self.reader)
         if max(self.flip_axes):
             flipimagefilter = sitk.FlipImageFilter()
             flipimagefilter.SetFlipAxes(self.flip_axes)

--- a/src/DicomRTTool/__init__.py
+++ b/src/DicomRTTool/__init__.py
@@ -143,14 +143,16 @@ def add_to_dictionary(frames_of_reference_dict, frame_of_reference, path, series
     :param dicom_type: "RT" or "Image"
     """
     if frame_of_reference not in frames_of_reference_dict.keys():
-        frames_of_reference_dict[frame_of_reference] = {'Images': [], 'Image_Series_UIDs': [],
+        frames_of_reference_dict[frame_of_reference] = {'Images': [], 'Images_Series_UIDs': [],
                                                         'RTs': [], 'RT_Series_UID': []}
-    elif dicom_type == 'Image':
-        frames_of_reference_dict[frame_of_reference]['Images'].append(path)
-        frames_of_reference_dict[frame_of_reference]['Image_Series_UIDs'].append(series_instance_uid)
-    elif dicom_type == 'RT':
-        frames_of_reference_dict[frame_of_reference]['RTs'].append(path)
-        frames_of_reference_dict[frame_of_reference]['RT_Series_UID'].append(series_instance_uid)
+    if dicom_type == 'Image':
+        key = 'Images'
+    else:
+        key = 'RT'
+    series_key = '{}_Series_UIDs'.format(key)
+    if series_instance_uid not in frames_of_reference_dict[frame_of_reference][series_key]:
+        frames_of_reference_dict[frame_of_reference][key].append(path)
+        frames_of_reference_dict[frame_of_reference][series_key].append(series_instance_uid)
 
 
 class DicomReaderWriter:

--- a/src/DicomRTTool/__init__.py
+++ b/src/DicomRTTool/__init__.py
@@ -140,12 +140,12 @@ def add_to_dictionary(frames_of_reference_dict, frame_of_reference, path, series
     :param frame_of_reference: a unique frame of reference
     :param path: path to the images or structure in question
     :param series_instance_uid: series instance UID for the object in question
-    :param dicom_type: "RT" or "Image"
+    :param dicom_type: "RT" or "Images"
     """
     if frame_of_reference not in frames_of_reference_dict.keys():
         frames_of_reference_dict[frame_of_reference] = {'Images': [], 'Images_Series_UIDs': [],
-                                                        'RTs': [], 'RT_Series_UID': []}
-    if dicom_type == 'Image':
+                                                        'RT': [], 'RT_Series_UID': []}
+    if dicom_type == 'Images':
         key = 'Images'
     else:
         key = 'RT'
@@ -474,7 +474,7 @@ class DicomReaderWriter:
         frame_of_ref = self.reader.GetMetaData(0, "0020|0052")
         add_to_dictionary(frames_of_reference_dict=self.Frames_of_Reference,
                           frame_of_reference=frame_of_ref, path=self.PathDicom,
-                          series_instance_uid=self.reader.GetMetaData(0, "0020|000e"), dicom_type='Image')
+                          series_instance_uid=self.reader.GetMetaData(0, "0020|000e"), dicom_type='Images')
         self.SOPInstanceUIDs = [self.reader.GetMetaData(i, sop_instance_UID_key) for i in
                                 range(self.dicom_handle.GetDepth())]
         if max(self.flip_axes):

--- a/src/DicomRTTool/__init__.py
+++ b/src/DicomRTTool/__init__.py
@@ -295,6 +295,7 @@ class DicomReaderWriter:
         :param ds: pydicom data structure
         :param path: path to the images or structure in question
         """
+        series_instance_uid = ds.SeriesInstanceUID
         for referenced_frame_of_reference in ds.ReferencedFrameOfReferenceSequence:
             for referred_study_sequence in referenced_frame_of_reference.RTReferencedStudySequence:
                 for referred_series in referred_study_sequence.RTReferencedSeriesSequence:
@@ -318,7 +319,8 @@ class DicomReaderWriter:
                             self.RTs_with_ROI_Names[Structures.ROIName.lower()] = [path]
                         else:
                             self.RTs_with_ROI_Names[Structures.ROIName.lower()].append(path)
-                    temp_dict = {path: {'ROI_Names': rois, 'ROIs_in_structure': rois_in_structure}}
+                    temp_dict = {series_instance_uid: {'Path': path, 'ROI_Names': rois,
+                                                       'ROIs_in_structure': rois_in_structure}}
                     self.all_RTs[path] = rois_in_structure
                     self.RTs_in_case[path] = rois_in_structure
                     self.series_instances_dictionary[referenced_series_instance_uid]['RTs'].update(temp_dict)

--- a/src/DicomRTTool/__init__.py
+++ b/src/DicomRTTool/__init__.py
@@ -134,7 +134,7 @@ def poly2mask(vertex_row_coords, vertex_col_coords, shape):
     return mask
 
 
-def add_to_dictionary(frames_of_reference_dict, frame_of_reference, path, series_instance_uid, dicom_type):
+def add_to_dictionary(frames_of_reference_dict, frame_of_reference, path, series_instance_uid, dicom_type='Images'):
     """
     :param frames_of_reference_dict: dictionary of frames_of_reference
     :param frame_of_reference: a unique frame of reference
@@ -144,7 +144,7 @@ def add_to_dictionary(frames_of_reference_dict, frame_of_reference, path, series
     """
     if frame_of_reference not in frames_of_reference_dict.keys():
         frames_of_reference_dict[frame_of_reference] = {'Images': [], 'Images_Series_UIDs': [],
-                                                        'RT': [], 'RT_Series_UID': []}
+                                                        'RT': [], 'RT_Series_UIDs': []}
     if dicom_type == 'Images':
         key = 'Images'
     else:


### PR DESCRIPTION
This branch was created in response to remove the necessity of dicom and RT structure files being placed in the same folder. Larger changes have been enacted. A dictionary is now created which associates images and other dicom structures to one another through the SeriesInstanceUIDs. As much backwards compatibility as possible has been worked in, but remains open to testing