### PR TITLE
Supporting roi type for import multiple geometries

### DIFF
--- a/src/DicomRTTool/ReaderWriter.py
+++ b/src/DicomRTTool/ReaderWriter.py
@@ -891,7 +891,13 @@ class DicomReaderWriter(object):
             self.RS_struct.RTROIObservationsSequence[self.struct_index].ObservationNumber = new_ROINumber
             self.RS_struct.RTROIObservationsSequence[self.struct_index].ReferencedROINumber = new_ROINumber
             self.RS_struct.RTROIObservationsSequence[self.struct_index].ROIObservationLabel = Name
-            self.RS_struct.RTROIObservationsSequence[self.struct_index].RTROIInterpretedType = 'ORGAN'
+            
+            if 'ctv' in Name.lower():
+                self.RS_struct.RTROIObservationsSequence[self.struct_index].RTROIInterpretedType = 'CTV'
+            elif 'ptv' in Name.lower():
+                self.RS_struct.RTROIObservationsSequence[self.struct_index].RTROIInterpretedType = 'PTV'
+            else:
+                self.RS_struct.RTROIObservationsSequence[self.struct_index].RTROIInterpretedType = 'ORGAN'
 
             if make_new == 1:
                 self.RS_struct.ROIContourSequence.insert(0, copy.deepcopy(self.RS_struct.ROIContourSequence[0]))


### PR DESCRIPTION
Really a dummy way of doing it.

But currently if you import RTstruct in RayStation and change the roi type from organ to CTV, when importing another geometry to another examination with a different roi type, RayStation creates a duplicate (roi name + (1)).

This make sure that imported CTV are always CTV type in the TPS.