### PR TITLE
updated poly2mask for depricated np.bool

### DIFF
--- a/src/DicomRTTool/ReaderWriter.py
+++ b/src/DicomRTTool/ReaderWriter.py
@@ -131,7 +131,7 @@ def poly2mask(vertex_row_coords: np.array, vertex_col_coords: np.array,
     coords = np.expand_dims(xy_coords.T, 0)
     mask = np.zeros(shape)
     cv2.fillPoly(mask, coords, 1)
-    return np.array(mask, dtype=np.bool)
+    return np.array(mask, dtype=bool)
 
 
 def add_images_to_dictionary(images_dictionary, dicom_names, sitk_dicom_reader,


### PR DESCRIPTION
This is to update the code for function poly2mask to use the dtype of `bool` type rather than `np.bool` as the numpy alias was [deprecated in numpy v1.20.](https://numpy.org/devdocs/release/1.20.0-notes.html#using-the-aliases-of-builtin-types-like-np-int-is-deprecated) 

By using `bool` instead of `np.bool_` this adjustment should support previous and future versions of numpy.