### PR TITLE
Fix contour-to-slice mapping on non-uniform-Z CT acquisitions

### DIFF
--- a/src/DicomRTTool/ReaderWriter.py
+++ b/src/DicomRTTool/ReaderWriter.py
@@ -177,6 +177,20 @@ class DicomReaderWriter:
         self._dicom_handle_uid: str | None = None
         self._dicom_info_uid: str | None = None
         self._rs_struct_uid: str | None = None
+        # Per-slice ImagePositionPatient[2] (mm) from the source DICOM
+        # series, in the same order as ``self.dicom_handle``'s Z axis.
+        # Populated by ``get_images()``; used by ``reshape_contour_data`` to
+        # map each contour plane's physical z-mm to a slice index by
+        # nearest-neighbour lookup against the actual per-DICOM IPP[2],
+        # avoiding the uniform-spacing assumption baked into
+        # ``TransformPhysicalPointToIndex``. Critical for non-uniform-Z
+        # CT acquisitions (mixed 3 mm / 6 mm slice gaps, common on
+        # NSCLC-Radiomics): the uniform-spacing path mis-rounds the z
+        # index for several contour planes per ROI and the resulting mask
+        # is missing slices. ``None`` when no series has been loaded yet
+        # or the IPP read failed; ``reshape_contour_data`` falls back to
+        # the legacy uniform-spacing path in that case.
+        self._dicom_slice_z_positions: np.ndarray | None = None
         self.mask: np.ndarray | None = None
         self._rd_study_instance_uid: str | None = None
         self.index = index
@@ -764,10 +778,47 @@ class DicomReaderWriter:
 
         add_sops(self.reader, self.series_instances_dictionary)
 
+        # Read each source DICOM's ImagePositionPatient[2] in the same order
+        # SimpleITK's ImageSeriesReader used (it sorts by IPP projection along
+        # the slice axis). On non-uniform-Z CT acquisitions (mixed 3 mm / 6 mm
+        # slice gaps), this per-slice array is the only correct way to map a
+        # contour z-mm to a CT slice index; SimpleITK's
+        # ``TransformPhysicalPointToIndex`` collapses the per-slice positions
+        # into a single averaged spacing and rounds away from the real slice.
+        # See ``reshape_contour_data`` for the consumer of this array.
+        try:
+            sorted_files = list(self.reader.GetFileNames())
+            slice_zs = []
+            for f in sorted_files:
+                sub = dcmread(f, stop_before_pixels=True)
+                ipp = getattr(sub, "ImagePositionPatient", None)
+                if ipp is None or len(ipp) < 3:
+                    raise ValueError(f"{f} has no ImagePositionPatient")
+                slice_zs.append(float(ipp[2]))
+            self._dicom_slice_z_positions = np.asarray(slice_zs, dtype=np.float64)
+        except Exception as exc:  # pragma: no cover - logged for diagnosis
+            logger.warning(
+                "Could not build per-slice Z lookup; falling back to "
+                "uniform-spacing TransformPhysicalPointToIndex (may misalign "
+                "contours on non-uniform-Z CTs). Reason: %s",
+                exc,
+            )
+            self._dicom_slice_z_positions = None
+
         if any(self.flip_axes):
             flip_filter = sitk.FlipImageFilter()
             flip_filter.SetFlipAxes(self.flip_axes)
             self.dicom_handle = flip_filter.Execute(self.dicom_handle)
+            # FlipImageFilter on the Z axis reverses the in-memory slice
+            # order. Keep the per-slice Z lookup in lockstep so
+            # ``reshape_contour_data`` resolves contour z-mm against the
+            # post-flip indices.
+            if (
+                self._dicom_slice_z_positions is not None
+                and len(self.flip_axes) >= 3
+                and self.flip_axes[2]
+            ):
+                self._dicom_slice_z_positions = self._dicom_slice_z_positions[::-1].copy()
 
         self.ArrayDicom = sitk.GetArrayFromImage(self.dicom_handle)
         self.image_size_cols, self.image_size_rows, self.image_size_z = (
@@ -913,11 +964,34 @@ class DicomReaderWriter:
     # -- Contour geometry ---------------------------------------------------
 
     def reshape_contour_data(self, contour_data: np.ndarray) -> np.ndarray:
-        """Convert flat contour data to Nx3 matrix of voxel indices."""
+        """Convert flat contour data to Nx3 matrix of voxel indices.
+
+        Uses SimpleITK's ``TransformPhysicalPointToIndex`` for the in-plane
+        (col, row) coordinates -- those are not sensitive to Z-spacing.
+        For the slice index, prefers a nearest-neighbour lookup against
+        the per-DICOM ``ImagePositionPatient[2]`` array cached in
+        ``self._dicom_slice_z_positions`` (correct on any Z-spacing
+        pattern including the non-uniform CT case). Falls back to the
+        ``TransformPhysicalPointToIndex`` Z when that array isn't
+        available -- which preserves the legacy behaviour on synthetic
+        test images that bypass ``get_images()``.
+        """
         pts = np.asarray(contour_data).reshape(-1, 3)
-        return np.array(
+        indices = np.array(
             [self.dicom_handle.TransformPhysicalPointToIndex(pts[i]) for i in range(len(pts))]
         )
+        if self._dicom_slice_z_positions is not None and len(self._dicom_slice_z_positions) > 0:
+            # Replace SimpleITK's uniform-spacing Z with the actual
+            # nearest-IPP slice index for every contour point. Identical
+            # output on uniform-Z CTs (rounding to the nearest of N
+            # uniform positions and the nearest-IPP lookup against those
+            # same N positions resolve to the same index); meaningfully
+            # different only when the per-slice IPPs are non-uniform.
+            slice_zs = self._dicom_slice_z_positions
+            for i in range(len(pts)):
+                z_mm = pts[i][2]
+                indices[i, 2] = int(np.argmin(np.abs(slice_zs - z_mm)))
+        return indices
 
     def return_mask(
         self, mask: np.ndarray, matrix_points: np.ndarray, geometric_type: str

--- a/tests/test_nonuniform_z_slice_matching.py
+++ b/tests/test_nonuniform_z_slice_matching.py
@@ -33,17 +33,13 @@ This test exercises three layers:
 """
 from __future__ import annotations
 
-from pathlib import Path
-
 import numpy as np
 import pydicom
 import pytest
-import SimpleITK as sitk
 
 from DicomRTTool.ReaderWriter import DicomReaderWriter
 
 from . import synthetic
-
 
 # ---------------------------------------------------------------------------
 # Layer 1 -- uniform-Z synthetic dataset (regression: fix is a no-op here)
@@ -127,7 +123,7 @@ def nonuniform_z_dataset(tmp_path_factory) -> dict:
         expected_zs.append(expected_zs[-1] + g)
     assert len(expected_zs) == 12
 
-    for f, z in zip(sorted(ct_dir.glob("slice_*.dcm")), expected_zs):
+    for f, z in zip(sorted(ct_dir.glob("slice_*.dcm")), expected_zs, strict=True):
         ds = pydicom.dcmread(str(f))
         ipp = list(ds.ImagePositionPatient)
         ipp[2] = float(z)
@@ -211,9 +207,8 @@ def test_reshape_contour_data_uses_nearest_ipp_when_available(synthetic_dataset)
     # Mixed 3 mm / 6 mm pattern, anchored at the synthetic origin so
     # X/Y indexing stays sensible.
     origin_z = r.dicom_handle.GetOrigin()[2]
-    spacing_z = r.dicom_handle.GetSpacing()[2]
     gaps = [3.0 if i % 4 != 2 else 6.0 for i in range(n_slices - 1)]
-    custom_zs = np.cumsum([0.0] + gaps) + origin_z
+    custom_zs = np.cumsum([0.0, *gaps]) + origin_z
     r._dicom_slice_z_positions = custom_zs
 
     # Pick a Z position that lands between two slices on the custom

--- a/tests/test_nonuniform_z_slice_matching.py
+++ b/tests/test_nonuniform_z_slice_matching.py
@@ -1,0 +1,266 @@
+"""Regression test for the non-uniform-Z slice-matching fix.
+
+Background
+==========
+
+Clinical CT acquisitions sometimes have **non-uniform Z spacing** -- e.g.
+mixed 3 mm and 6 mm slice gaps where the scanner skipped or doubled up
+on certain regions. This is common on the NSCLC-Radiomics public cohort
+(LUNG1-014/-021/-085/-095/-194/-246 all have it).
+
+The legacy ``DicomReaderWriter.reshape_contour_data`` used SimpleITK's
+``TransformPhysicalPointToIndex`` to map every contour point's physical
+coordinate to a voxel index. On non-uniform-Z series, ITK's
+``ImageSeriesReader`` compresses the per-slice positions into a single
+*averaged* spacing[2]; the per-point index then rounds against that
+averaged spacing and misses contour planes that sit on the irregular
+side of the gap. Empirically that costs 11-14 of ~73 contour planes on
+LUNG1-014's lung ROIs.
+
+The fix caches the per-DICOM ``ImagePositionPatient[2]`` array during
+``get_images()`` and resolves each contour plane's Z to the nearest
+actual slice instead.
+
+This test exercises three layers:
+
+1. The per-slice Z array is populated on a uniform-Z synthetic dataset
+   and matches the uniform grid (no regression).
+2. The per-slice Z array is populated correctly when loading a
+   non-uniform-Z CT series.
+3. ``reshape_contour_data`` resolves contour Z's against the per-slice
+   array when available, falling back to the legacy
+   ``TransformPhysicalPointToIndex`` path otherwise.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+import pydicom
+import pytest
+import SimpleITK as sitk
+
+from DicomRTTool.ReaderWriter import DicomReaderWriter
+
+from . import synthetic
+
+
+# ---------------------------------------------------------------------------
+# Layer 1 -- uniform-Z synthetic dataset (regression: fix is a no-op here)
+# ---------------------------------------------------------------------------
+
+
+def test_per_slice_z_populated_on_uniform_dataset(synthetic_dataset):
+    """After loading the uniform-Z synthetic dataset that the rest of the
+    test suite uses, the reader caches the per-DICOM IPP[2] array with
+    the exact uniform spacing the dataset was built with.
+
+    A regression in ``get_images()`` would leave the array unset (the
+    fix would silently degrade to the legacy path) or populate it with
+    the wrong values; both are caught here."""
+    r = DicomReaderWriter(
+        description="uniform_z_check",
+        Contour_Names=[p.name for p in synthetic_dataset.primitives],
+        arg_max=True,
+        verbose=False,
+    )
+    r.walk_through_folders(str(synthetic_dataset.walk_root), thread_count=1)
+    r.set_index(r.indexes_with_contours[0])
+    r.get_images_and_mask()
+
+    assert r._dicom_slice_z_positions is not None
+    z_arr = np.asarray(r._dicom_slice_z_positions)
+    assert len(z_arr) == synthetic_dataset.geometry.size[2]
+    diffs = np.diff(z_arr)
+    sz = synthetic_dataset.geometry.spacing[2]
+    np.testing.assert_allclose(diffs, sz, atol=1e-6)
+
+
+# ---------------------------------------------------------------------------
+# Layer 2 -- non-uniform-Z CT: per-slice Z array tracks the mixed gaps
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="module")
+def nonuniform_z_dataset(tmp_path_factory) -> dict:
+    """Build a synthetic CT then rewrite its per-slice IPP[2] to a
+    mixed-3/6 mm pattern. The RTSTRUCT shipped alongside the CT is
+    intentionally aligned to the *original* (uniform 1 mm) Z grid -- the
+    test below only inspects the cached per-slice array, not the
+    mask itself, so the contour positions don't need to match the new
+    IPPs.
+
+    Returns the dataset's filesystem layout and the expected per-slice
+    Z array.
+    """
+    out = tmp_path_factory.mktemp("nonuniform_z")
+    ct_dir = out / "CT"
+    rt_path = out / "RT.dcm"
+
+    # Build a 12-slice CT with the existing synthetic helper (uniform Z),
+    # then we'll override the IPP[2] of each slice after the fact.
+    geometry = synthetic.Geometry(
+        size=(64, 64, 12),
+        origin=(0.0, 0.0, 0.0),
+        spacing=(2.0, 2.0, 1.0),
+    )
+    sphere = synthetic.Sphere(
+        name="Sphere_nonuniform",
+        center=(30.0, 30.0, 5.5),
+        radius=8.0,
+    )
+    uids = synthetic.CTSeriesUIDs()
+    sop_uids = synthetic.build_synthetic_ct(
+        ct_dir, geometry, uids, [sphere], modality="CT",
+    )
+    synthetic.build_synthetic_rtstruct(
+        rt_path, geometry, uids, sop_uids, [sphere], image_modality="CT",
+    )
+
+    # Override each CT slice's ImagePositionPatient[2] (and SliceLocation)
+    # to a mixed 3 mm / 6 mm pattern. The slices are written in
+    # ``slice_0000.dcm``-order, which is also Z-ascending in the
+    # synthetic helper.
+    gaps = [3.0, 3.0, 3.0, 6.0, 6.0, 3.0, 3.0, 3.0, 3.0, 3.0, 3.0]
+    expected_zs = [0.0]
+    for g in gaps:
+        expected_zs.append(expected_zs[-1] + g)
+    assert len(expected_zs) == 12
+
+    for f, z in zip(sorted(ct_dir.glob("slice_*.dcm")), expected_zs):
+        ds = pydicom.dcmread(str(f))
+        ipp = list(ds.ImagePositionPatient)
+        ipp[2] = float(z)
+        ds.ImagePositionPatient = ipp
+        ds.SliceLocation = float(z)
+        ds.save_as(str(f), enforce_file_format=True, little_endian=True, implicit_vr=False)
+
+    return {
+        "walk_root": out,
+        "ct_dir": ct_dir,
+        "rt_path": rt_path,
+        "expected_zs": np.asarray(expected_zs, dtype=np.float64),
+        "sphere_name": sphere.name,
+    }
+
+
+def test_per_slice_z_tracks_nonuniform_gaps(nonuniform_z_dataset):
+    """Loading a CT with mixed 3/6 mm Z gaps should cache the per-DICOM
+    IPP[2] values *exactly* -- including the 6 mm jumps. Failure here
+    indicates the read path silently truncates / smooths the per-slice
+    Z information (the underlying problem the fix exists to solve)."""
+    r = DicomReaderWriter(
+        description="nonuniform_z_check",
+        Contour_Names=[nonuniform_z_dataset["sphere_name"]],
+        arg_max=True,
+        verbose=False,
+    )
+    r.walk_through_folders(str(nonuniform_z_dataset["walk_root"]), thread_count=1)
+    r.set_index(r.indexes_with_contours[0])
+    r.get_images_and_mask()
+
+    assert r._dicom_slice_z_positions is not None
+    z_arr = np.asarray(r._dicom_slice_z_positions)
+    np.testing.assert_allclose(
+        z_arr, nonuniform_z_dataset["expected_zs"], atol=1e-6,
+        err_msg="cached per-slice Z array does not match the per-DICOM IPP[2]",
+    )
+
+    # The SimpleITK image's spacing[2] should NOT match any individual
+    # gap -- ITK averages, so non-uniform input collapses to one number.
+    # This is the precise reason the fix is needed.
+    avg_spacing = r.dicom_handle.GetSpacing()[2]
+    assert avg_spacing != pytest.approx(3.0), (
+        "SimpleITK averaged spacing happened to equal 3 mm; the test "
+        "fixture isn't exercising the non-uniform case."
+    )
+    assert avg_spacing != pytest.approx(6.0), (
+        "SimpleITK averaged spacing happened to equal 6 mm; the test "
+        "fixture isn't exercising the non-uniform case."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Layer 3 -- reshape_contour_data uses the array when available
+# ---------------------------------------------------------------------------
+
+
+def test_reshape_contour_data_uses_nearest_ipp_when_available(synthetic_dataset):
+    """``reshape_contour_data`` should resolve each contour Z to the
+    nearest cached per-slice Z (and ignore SimpleITK's uniform-spacing
+    answer) whenever ``_dicom_slice_z_positions`` is populated.
+
+    We inject a custom non-uniform per-slice array and a tiny contour
+    whose physical Z lands closer to a slice the legacy round-via-
+    spacing path would not pick. Verifies the array is *actually used*
+    rather than only stored."""
+    r = DicomReaderWriter(
+        description="reshape_unit_test",
+        Contour_Names=[p.name for p in synthetic_dataset.primitives],
+        arg_max=True,
+        verbose=False,
+    )
+    r.walk_through_folders(str(synthetic_dataset.walk_root), thread_count=1)
+    r.set_index(r.indexes_with_contours[0])
+    r.get_images_and_mask()
+
+    # Override the cached per-slice Z array with a synthetic mixed-gap
+    # pattern. dicom_handle's averaged spacing stays whatever the
+    # uniform synthetic dataset built.
+    n_slices = r.dicom_handle.GetSize()[2]
+    # Mixed 3 mm / 6 mm pattern, anchored at the synthetic origin so
+    # X/Y indexing stays sensible.
+    origin_z = r.dicom_handle.GetOrigin()[2]
+    spacing_z = r.dicom_handle.GetSpacing()[2]
+    gaps = [3.0 if i % 4 != 2 else 6.0 for i in range(n_slices - 1)]
+    custom_zs = np.cumsum([0.0] + gaps) + origin_z
+    r._dicom_slice_z_positions = custom_zs
+
+    # Pick a Z position that lands between two slices on the custom
+    # array. The nearest-IPP lookup should pick the closer of the two,
+    # which is generally NOT what the uniform-spacing rounding picks.
+    target_z = float(custom_zs[3] - 0.4)  # 0.4 mm below slice 3
+    expected_idx = int(np.argmin(np.abs(custom_zs - target_z)))
+    # x and y at the volume center (legal indices)
+    cx = r.dicom_handle.GetOrigin()[0] + r.dicom_handle.GetSpacing()[0] * 8
+    cy = r.dicom_handle.GetOrigin()[1] + r.dicom_handle.GetSpacing()[1] * 8
+    contour = np.array([cx, cy, target_z], dtype=np.float64)
+    out = r.reshape_contour_data(contour)
+    assert out.shape == (1, 3)
+    assert out[0, 2] == expected_idx, (
+        f"reshape_contour_data did not use the per-slice array. "
+        f"Expected slice index {expected_idx} (nearest to z={target_z}); "
+        f"got {int(out[0, 2])}. custom_zs={custom_zs.tolist()}"
+    )
+
+
+def test_reshape_contour_data_falls_back_when_array_missing(synthetic_dataset):
+    """When ``_dicom_slice_z_positions`` is None (e.g. IPP read failed),
+    ``reshape_contour_data`` must fall back to SimpleITK's
+    ``TransformPhysicalPointToIndex``. Without this fallback the fix
+    would crash on legitimate but unusual inputs (anonymized series
+    with stripped IPP tags, etc.)."""
+    r = DicomReaderWriter(
+        description="fallback_test",
+        Contour_Names=[p.name for p in synthetic_dataset.primitives],
+        arg_max=True,
+        verbose=False,
+    )
+    r.walk_through_folders(str(synthetic_dataset.walk_root), thread_count=1)
+    r.set_index(r.indexes_with_contours[0])
+    r.get_images_and_mask()
+
+    # Force the per-slice array to None and re-run a contour through
+    # the reshape path; output should match what
+    # TransformPhysicalPointToIndex returns directly.
+    r._dicom_slice_z_positions = None
+    origin = r.dicom_handle.GetOrigin()
+    spacing = r.dicom_handle.GetSpacing()
+    target = np.array([
+        origin[0] + spacing[0] * 8,
+        origin[1] + spacing[1] * 8,
+        origin[2] + spacing[2] * 5,
+    ], dtype=np.float64)
+    out = r.reshape_contour_data(target)
+    expected = np.asarray(r.dicom_handle.TransformPhysicalPointToIndex(target))
+    np.testing.assert_array_equal(out[0], expected)


### PR DESCRIPTION
## Summary

Mirrors the fix that just landed in the C# RTSTRUCT-to-NIfTI converter (``brianmanderson/DicomRtNiftiConverterGUI`` PR #11). Same root cause, same shape of fix, same empirical impact: a small number of clinical CT scans use **non-uniform Z spacing** (e.g. mixed 3 mm / 6 mm slice gaps on NSCLC-Radiomics LUNG1-014/-021/-085/-095/-194/-246), and ``DicomReaderWriter`` previously rounded each RTSTRUCT contour plane's Z to the wrong CT slice for the gappy region.

## Root cause

``DicomReaderWriter.reshape_contour_data`` used SimpleITK's ``TransformPhysicalPointToIndex`` to map every contour point's physical ``(x, y, z)`` to a voxel index. ITK's ``ImageSeriesReader`` collapses the per-slice Z positions into a single, **averaged** ``spacing[2]``; the per-point Z then rounds against that averaged value and misses contour planes that sit on the irregular side of the gap.

Empirically, on the affected NSCLC-Radiomics patients this misses **11-14 of ~73** RTSTRUCT-stated contour planes for lung ROIs and adds 2 spurious slices outside the contour range.

## Implementation

* ``DicomReaderWriter._dicom_slice_z_positions`` (new instance attribute): cached ``numpy`` array of per-DICOM ``ImagePositionPatient[2]`` values for the currently loaded series, in the same order as the SimpleITK image's Z axis. ``None`` until ``get_images()`` runs (or on IPP read failure).

* ``get_images()``: after ``self.dicom_handle = self.reader.Execute()``, walks ``self.reader.GetFileNames()`` and reads each file's ``ImagePositionPatient[2]`` into the new array. Honors any ``FlipImageFilter`` on the Z axis by reversing the array to keep it in lockstep with the image's array order.

* ``reshape_contour_data()``: keeps using ``TransformPhysicalPointToIndex`` for the in-plane ``(col, row)`` coordinates (those aren't sensitive to Z spacing), but overrides the Z column with a ``np.argmin(|cached_Z - contour_z|)`` nearest-neighbour lookup when the cached array is available. Falls back to the legacy ``TransformPhysicalPointToIndex`` Z when the cached array is ``None``, preserving behaviour on the unusual case where IPP reads fail (e.g. heavily-anonymized series with stripped tags).

## Backward compatibility

The legacy path is preserved as a fallback. On uniform-Z CTs the new nearest-IPP lookup and the legacy round-via-spacing path return **bit-identical** slice indices -- both algorithms resolve to the same integer index when the per-slice positions form a uniform grid.

Verified: **all 92 pre-existing tests pass unchanged**. The fix is invisible on every uniform-Z synthetic + clinical dataset already in the test suite.

## New regression tests (`tests/test_nonuniform_z_slice_matching.py`)

Four cases:

1. ``test_per_slice_z_populated_on_uniform_dataset`` -- cached array exists after loading the uniform-Z synthetic dataset and has the exact uniform spacing the fixture was built with.

2. ``test_per_slice_z_tracks_nonuniform_gaps`` -- loads a CT whose per-slice ``ImagePositionPatient[2]`` was rewritten to a mixed 3/6 mm pattern. Cached array matches the per-DICOM IPP exactly, *and* the SimpleITK averaged ``spacing[2]`` is confirmed not to equal any individual gap (i.e. the fixture really exercises the non-uniform case).

3. ``test_reshape_contour_data_uses_nearest_ipp_when_available`` -- injects a custom non-uniform array into a reader and verifies ``reshape_contour_data`` resolves a contour Z to the array-nearest slice (and *not* the SimpleITK uniform-spacing answer). Confirms the array isn't just stored but actually used.

4. ``test_reshape_contour_data_falls_back_when_array_missing`` -- with the cached array forced to ``None``, ``reshape_contour_data`` produces the same indices as a direct ``TransformPhysicalPointToIndex`` call. Defends against IPP read failures on stripped/anonymized series.

## Cross-tool context

This is part of a coordinated fix across all comparator tools that exhibited the same bug. Status as of this PR:

| Tool | Status |
|---|---|
| **DicomRTTool** | **this PR** |
| **C# Dicom_RT_images_Csharp** | merged (``DicomRtNiftiConverterGUI`` PR #11) |
| dcmrtstruct2nii | TODO (separate PR) |
| platipy | TODO (separate PR) |
| plastimatch | TODO (upstream fix or post-process workaround) |
| rt_utils | already correct (uses per-DICOM nearest-slice lookup) |
| pyradise | already correct (same) |