### PR TITLE
Add per-ROI DICOM→NIfTI export, output resampling, and anonymization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,15 @@ tool. All additions are backward compatible — existing APIs are unchanged.
   per-ROI mask volume in cc (`-1` when an ROI is absent for that series). No
   persistent iteration index is maintained (unlike `write_parallel`, which is
   kept for backward compatibility).
+- **`DicomReaderWriter.create_manifest(output_path, ...)`** — a metadata-only
+  manifest writer mirroring the C# `export_manifest.csv`: one row per
+  series-with-contours with the image spacing (`spacing_x/y/z`) and the mask
+  volume in cc for every ROI name (`-1` when absent). No NIfTI files are
+  written. If the CSV already exists it is **read and extended in place** —
+  series already present (matched by `SeriesInstanceUID` or `series_hash`) are
+  left untouched, new series are appended, and new ROI columns are backfilled
+  with `-1` for pre-existing rows — so it is safe to call repeatedly while
+  walking more data. Supports `anonymize=True` for hashed-only identifiers.
 - **Output resampling** — an optional `output_spacing` tuple on both
   `write_per_roi` and `write_images_annotations` resamples outputs to a target
   voxel spacing: **linear** interpolation for images and dose, **nearest
@@ -45,7 +54,7 @@ tool. All additions are backward compatible — existing APIs are unchanged.
   auto-skips unless `DICOMRTTOOL_LCTSC_DIR` and `DICOMRTTOOL_CSHARP_EXE` are
   set, so the hermetic suite and CI are unaffected. New hermetic unit tests:
   `tests/test_anonymizer.py`, `tests/test_resample.py`,
-  `tests/test_per_roi_export.py`.
+  `tests/test_per_roi_export.py`, `tests/test_create_manifest.py`.
 
 ### Notes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,9 +33,13 @@ tool. All additions are backward compatible — existing APIs are unchanged.
 - **Output resampling** — an optional `output_spacing` tuple on both
   `write_per_roi` and `write_images_annotations` resamples outputs to a target
   voxel spacing: **linear** interpolation for images and dose, **nearest
-  neighbour** for masks (labels are never blended). The reusable
-  `resample_to_spacing(handle, output_spacing, interpolator)` helper is
-  exported from the package.
+  neighbour** for masks (labels are never blended). When resampling, the dose
+  is resampled onto the **resampled image grid** (via the new
+  `resample_to_reference` helper) rather than its own grid, so the image,
+  masks, and dose all share one size & geometry. The reusable
+  `resample_to_spacing(handle, output_spacing, interpolator)` and
+  `resample_to_reference(handle, reference, interpolator)` helpers are exported
+  from the package.
 - **Anonymization** — deterministic SHA-256 identifier hashing matching the
   C# `AnonymizationService` byte-for-byte: `hash_patient` (prefix `P`, 5
   bytes), `hash_study` (`ST`, 6 bytes), `hash_series` (`SE`, 6 bytes), the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,57 @@ All notable changes to this project are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [Unreleased]
+
+Ports the DICOM→NIfTI feature set from the companion C# `DicomRtNifti.Cli`
+tool. All additions are backward compatible — existing APIs are unchanged.
+
+### Added
+
+- **`DicomReaderWriter.write_per_roi(...)`** — bulk export of every
+  series-with-contours to a per-ROI NIfTI layout that matches the C# tool:
+  `<case_id>/image.nii.gz`, `<case_id>/masks/<roi>.nii.gz`, and
+  `<case_id>/doses/<desc>.nii.gz` (the latter only when `get_dose_output=True`
+  and the series carries dose). A single `manifest.csv` is written with one
+  row per series — patient/study/series identifiers, output spacing, and the
+  per-ROI mask volume in cc (`-1` when an ROI is absent for that series). No
+  persistent iteration index is maintained (unlike `write_parallel`, which is
+  kept for backward compatibility).
+- **Output resampling** — an optional `output_spacing` tuple on both
+  `write_per_roi` and `write_images_annotations` resamples outputs to a target
+  voxel spacing: **linear** interpolation for images and dose, **nearest
+  neighbour** for masks (labels are never blended). The reusable
+  `resample_to_spacing(handle, output_spacing, interpolator)` helper is
+  exported from the package.
+- **Anonymization** — deterministic SHA-256 identifier hashing matching the
+  C# `AnonymizationService` byte-for-byte: `hash_patient` (prefix `P`, 5
+  bytes), `hash_study` (`ST`, 6 bytes), `hash_series` (`SE`, 6 bytes), the
+  low-level `deterministic_hash_string`, and an `AnonymizationKey` class that
+  loads/saves the reverse-lookup JSON key file. With `write_per_roi(...,
+  anonymize=True)` the manifest carries only hashes, case folders are named by
+  the series hash, and an `anonymization_key.json` is written.
+- **New public exports** from `DicomRTTool`: `resample_to_spacing`,
+  `hash_patient`, `hash_study`, `hash_series`, `deterministic_hash_string`,
+  `AnonymizationKey`.
+- **Cross-tool evaluation harness** under `evaluation/`
+  (`compare_with_csharp.py` + `csharp_eval.py`) that runs DicomRTTool and the
+  C# tool live on TCIA LCTSC patients and compares mask generation (Dice /
+  volume), image generation (voxel MAE / geometry), and the resampling
+  feature. An opt-in `tests/test_csharp_parity.py` exercises it and
+  auto-skips unless `DICOMRTTOOL_LCTSC_DIR` and `DICOMRTTOOL_CSHARP_EXE` are
+  set, so the hermetic suite and CI are unaffected. New hermetic unit tests:
+  `tests/test_anonymizer.py`, `tests/test_resample.py`,
+  `tests/test_per_roi_export.py`.
+
+### Notes
+
+- The two tools use different polygon-boundary conventions (DicomRTTool is
+  boundary-inclusive; the C# tool fills the polygon interior), so masks agree
+  closely but are not byte-identical. On a 10-patient LCTSC sweep the live
+  comparison gives a median Dice of ~0.99 for large OARs (lower for thin
+  structures such as esophagus/cord), MAE 0.0 for native image generation,
+  and ~0.4 HU MAE for resample parity.
+
 ## [4.0.0] — 2026-05-01
 
 A modernization release. Breaking changes are limited to the removal of

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,24 @@ tool. All additions are backward compatible — existing APIs are unchanged.
   `tests/test_anonymizer.py`, `tests/test_resample.py`,
   `tests/test_per_roi_export.py`, `tests/test_create_manifest.py`.
 
+### Performance
+
+- **Mask rasterisation is ~2.4× faster.** `get_mask` no longer rescans the
+  entire multi-channel mask array once per ROI (the old
+  `self.mask[self.mask > 1] = 1` was an O(n_rois) pass over every voxel); it
+  now unions each ROI into its own channel with `np.maximum`. On a 46-ROI head
+  CT this alone cut `get_mask` from ~61 s to ~27 s.
+- **Per-ROI rasterisation can run in parallel.** A new `mask_thread_count`
+  constructor argument (default `1` = serial, unchanged behaviour) rasterises
+  independent ROIs across threads — the heavy inner work (SimpleITK transforms,
+  `cv2.fillPoly`, numpy) releases the GIL, giving ~2× on that stage. The bulk
+  writers (`create_manifest`, `write_per_roi`) auto-tune it: spare cores go to
+  per-ROI threads when only a few series are processed, while many-series runs
+  keep masks serial so the existing series-level parallelism isn't
+  oversubscribed. End to end, `create_manifest` on a single 46-ROI series drops
+  from ~64 s to ~26 s. Output is byte-identical to the serial path (covered by
+  `tests/test_mask_rasterization.py`).
+
 ### Notes
 
 - The two tools use different polygon-boundary conventions (DicomRTTool is

--- a/Examples/DICOMRTTool_Tutorial.ipynb
+++ b/Examples/DICOMRTTool_Tutorial.ipynb
@@ -69,7 +69,7 @@
     "├── Nifti_Data/ <- Generated when you run the cells below\n",
     "|   ├──Image.nii\n",
     "|   ├──Mask.nii\n",
-    "|   ├──MRN_Path_To_Iteration.xlsx\n",
+    "|   ├──MRN_Path_To_Iteration.csv\n",
     "|   ├──Overall_Data_Examples_(iteration)0.nii.gz \n",
     "|   ├──Overall_mask_Examples_y(iteration)0.nii.gz \n",
     "├── Numpy_Data/ <- Generated when you run the cells below\n",
@@ -1076,7 +1076,7 @@
     }
    },
    "source": [
-    "One can also use the built in .write_parallel attribute to generate nifti files for all relevant pairs the DicomReaderWriter object has found/generated. In this case there are 9 image/mask pairs for unique UIDs that contain all contours we are interested in. Note a corresponding log excel file in the specified output path. The nifti files are written in the following format: \"Overall_Data_{description}_ {iteration}.nii.gz\" (image) or \"Overall_mask_{description}_ y{iteration}.nii.gz\" (mask)."
+    "One can also use the built in .write_parallel attribute to generate nifti files for all relevant pairs the DicomReaderWriter object has found/generated. In this case there are 9 image/mask pairs for unique UIDs that contain all contours we are interested in. Note a corresponding log CSV file (the index file) in the specified output path. The nifti files are written in the following format: \"Overall_Data_{description}_ {iteration}.nii.gz\" (image) or \"Overall_mask_{description}_ y{iteration}.nii.gz\" (mask)."
    ]
   },
   {
@@ -1101,7 +1101,7 @@
    "source": [
     "%%time\n",
     "%%capture\n",
-    "Dicom_reader.write_parallel(out_path = nifti_path, excel_file = os.path.join(nifti_path,'.','MRN_Path_To_Iteration.xlsx'))"
+    "Dicom_reader.write_parallel(out_path = nifti_path, index_file = os.path.join(nifti_path,'.','MRN_Path_To_Iteration.csv'))"
    ]
   },
   {
@@ -1112,7 +1112,7 @@
     }
    },
    "source": [
-    "We can now reload the nifti files and disaply them to check that nothing went wrong. You can inspect the other converted files by changing the numerical suffix as per the excel log file ('MRN_Path_To_Iteration.xlsx')."
+    "We can now reload the nifti files and disaply them to check that nothing went wrong. You can inspect the other converted files by changing the numerical suffix as per the CSV log file ('MRN_Path_To_Iteration.csv')."
    ]
   },
   {

--- a/README.md
+++ b/README.md
@@ -136,8 +136,10 @@ is absent from that series).
 
 Pass an `output_spacing` tuple (mm) to resample on the way out. Images and
 dose are resampled with **linear** interpolation, masks with
-**nearest-neighbour** so labels are never blended. The same option is
-available on the single-series writer `write_images_annotations`:
+**nearest-neighbour** so labels are never blended. The dose is resampled onto
+the **resampled image grid**, so the image, masks, and dose all come out the
+same size and geometry. The same option is available on the single-series
+writer `write_images_annotations`:
 
 ```python
 reader.write_per_roi("/path/to/out", output_spacing=(1.0, 1.0, 3.0))

--- a/README.md
+++ b/README.md
@@ -165,6 +165,57 @@ from DicomRTTool import hash_patient, hash_study, hash_series, AnonymizationKey
 hash_patient("1234567")          # -> 'P...'  (prefix + 5 bytes of SHA-256)
 ```
 
+## Metadata manifest (`create_manifest`)
+
+When you only want the metadata table — **not** the NIfTI files —
+`create_manifest` writes a single CSV that mirrors the companion C# tool's
+`export_manifest.csv`: one row per series-with-contours, with the image
+spacing and the mask volume (cc) of every ROI. It records, per series:
+
+- the identifiers (`patient_hash`, `study_hash`, `series_hash`, and the raw
+  `PatientID` / `StudyInstanceUID` / `SeriesInstanceUID` unless `anonymize=True`);
+- the image spacing (`spacing_x`, `spacing_y`, `spacing_z`);
+- one `<roi> cc` column per ROI name — the mask volume in cubic centimetres,
+  or `-1` when that ROI is absent from the series.
+
+```python
+reader = DicomReaderWriter(
+    description="manifest",
+    Contour_Names=["tumor", "cord"],
+    require_all_contours=False,   # include series that carry only some ROIs
+)
+reader.walk_through_folders("/path/to/dicom")
+reader.create_manifest("/path/to/manifest.csv")
+
+# Anonymized identifiers only:
+reader.create_manifest("/path/to/manifest.csv", anonymize=True, salt="MyProjectSalt")
+```
+
+### Incremental updates (resumes an existing file)
+
+If the target CSV already exists, `create_manifest` **reads it and extends it
+in place** instead of overwriting. Series already recorded (matched by
+`SeriesInstanceUID`, or `series_hash` when anonymized) are left untouched, only
+newly walked series are appended, and any new ROI columns are added — with `-1`
+backfilled for the rows that predate them. This makes it safe to call
+repeatedly as you walk more data:
+
+```python
+# First batch
+reader.walk_through_folders("/data/batch1")
+reader.create_manifest("/path/to/manifest.csv")
+
+# Later: walk more patients and keep populating the same file —
+# existing rows are preserved, only new series are added.
+reader.reset()
+reader.walk_through_folders("/data/batch2")
+reader.create_manifest("/path/to/manifest.csv")
+```
+
+(`write_per_roi` writes the same-shape manifest alongside the NIfTI tree; use
+`create_manifest` when you want the table on its own or want to grow it over
+multiple runs.)
+
 ## Cross-tool evaluation
 
 The [`evaluation/`](evaluation/) directory contains an opt-in harness that
@@ -180,6 +231,8 @@ external dataset and the built C# binary.
 - **`write_per_roi`** — bulk DICOM→NIfTI export to a per-ROI layout
   (`<case>/image.nii.gz`, `<case>/masks/<roi>.nii.gz`, `<case>/doses/…`) with
   a single `manifest.csv` and no persistent index.
+- **`create_manifest`** — write (or incrementally extend) a metadata-only CSV
+  of per-series image spacing and per-ROI volumes, mirroring the C# manifest.
 - **Output resampling** — `output_spacing` on `write_per_roi` and
   `write_images_annotations`, plus the public `resample_to_spacing` helper
   (linear for image/dose, nearest-neighbour for masks).

--- a/README.md
+++ b/README.md
@@ -99,6 +99,95 @@ reader.prediction_array_to_RT(
 )
 ```
 
+## Bulk export to a per-ROI NIfTI layout
+
+`write_per_roi` converts every indexed series-with-contours into a tidy,
+per-case folder tree — one file per ROI — plus a single `manifest.csv`
+(one row per series). No persistent iteration index is maintained. This
+mirrors the layout used by the companion C# DICOM→NIfTI tool:
+
+```text
+out/
+  <case_id>/
+    image.nii.gz
+    masks/
+      tumor.nii.gz
+      cord.nii.gz
+    doses/                 # only when get_dose_output=True and dose exists
+      plan.nii.gz
+  manifest.csv             # patient/study/series ids, spacing, per-ROI volume (cc)
+```
+
+```python
+reader = DicomReaderWriter(
+    description="export",
+    Contour_Names=["tumor", "cord"],
+    require_all_contours=False,   # a series may carry only some ROIs (others -> -1)
+)
+reader.walk_through_folders("/path/to/dicom")
+reader.write_per_roi("/path/to/out")
+```
+
+Each manifest row records the patient/study/series identifiers, the output
+spacing, and the mask volume in cc for every requested ROI (`-1` when an ROI
+is absent from that series).
+
+### Resampling outputs to a target spacing
+
+Pass an `output_spacing` tuple (mm) to resample on the way out. Images and
+dose are resampled with **linear** interpolation, masks with
+**nearest-neighbour** so labels are never blended. The same option is
+available on the single-series writer `write_images_annotations`:
+
+```python
+reader.write_per_roi("/path/to/out", output_spacing=(1.0, 1.0, 3.0))
+reader.write_images_annotations("/path/to/out", output_spacing=(1.0, 1.0, 3.0))
+
+# Or resample any SimpleITK handle directly:
+from DicomRTTool import resample_to_spacing
+resampled = resample_to_spacing(reader.dicom_handle, (1.0, 1.0, 3.0), "Linear")
+```
+
+### Anonymized export
+
+With `anonymize=True`, identifiers are replaced by deterministic SHA-256
+hashes (patient MRN → patient hash, study hash, series hash), the case folder
+is named by the series hash, and an `anonymization_key.json` reverse-lookup
+file is written alongside the manifest. The hashing matches the companion C#
+tool byte-for-byte, so the two tools produce identical hashes for the same
+salt:
+
+```python
+reader.write_per_roi("/path/to/out", anonymize=True, salt="MyProjectSalt")
+
+# Stand-alone helpers are exported too:
+from DicomRTTool import hash_patient, hash_study, hash_series, AnonymizationKey
+hash_patient("1234567")          # -> 'P...'  (prefix + 5 bytes of SHA-256)
+```
+
+## Cross-tool evaluation
+
+The [`evaluation/`](evaluation/) directory contains an opt-in harness that
+runs DicomRTTool and the companion C# `DicomRtNifti.Cli` tool side by side on
+TCIA LCTSC patients and compares mask generation (Dice / volume), image
+generation (voxel MAE / geometry), and the resampling feature. See
+[`evaluation/README.md`](evaluation/README.md). It is never part of the
+hermetic test suite — the parity pytest auto-skips unless you point it at the
+external dataset and the built C# binary.
+
+## What's new since v4.0
+
+- **`write_per_roi`** — bulk DICOM→NIfTI export to a per-ROI layout
+  (`<case>/image.nii.gz`, `<case>/masks/<roi>.nii.gz`, `<case>/doses/…`) with
+  a single `manifest.csv` and no persistent index.
+- **Output resampling** — `output_spacing` on `write_per_roi` and
+  `write_images_annotations`, plus the public `resample_to_spacing` helper
+  (linear for image/dose, nearest-neighbour for masks).
+- **Anonymization** — deterministic SHA-256 hashing (`hash_patient` /
+  `hash_study` / `hash_series` / `AnonymizationKey`) for anonymized exports,
+  matching the companion C# tool.
+- **Cross-tool evaluation harness** under `evaluation/`.
+
 ## What's new in v4.0
 
 - **Python 3.10+** required (3.8 / 3.9 are end-of-life).

--- a/README.md
+++ b/README.md
@@ -178,17 +178,24 @@ spacing and the mask volume (cc) of every ROI. It records, per series:
 - one `<roi> cc` column per ROI name — the mask volume in cubic centimetres,
   or `-1` when that ROI is absent from the series.
 
+If you don't set `Contour_Names` (and don't pass `rois=`), `create_manifest`
+records **every ROI discovered during the walk** — so the simplest case just
+works:
+
 ```python
-reader = DicomReaderWriter(
-    description="manifest",
-    Contour_Names=["tumor", "cord"],
-    require_all_contours=False,   # include series that carry only some ROIs
-)
+reader = DicomReaderWriter(description="manifest")
 reader.walk_through_folders("/path/to/dicom")
-reader.create_manifest("/path/to/manifest.csv")
+reader.create_manifest("/path/to/manifest.csv")   # one column per discovered ROI
 
 # Anonymized identifiers only:
 reader.create_manifest("/path/to/manifest.csv", anonymize=True, salt="MyProjectSalt")
+```
+
+To restrict the manifest to specific ROIs, either set `Contour_Names` on the
+reader or pass them explicitly:
+
+```python
+reader.create_manifest("/path/to/manifest.csv", rois=["tumor", "cord"])
 ```
 
 ### Incremental updates (resumes an existing file)

--- a/README.md
+++ b/README.md
@@ -223,6 +223,20 @@ reader.create_manifest("/path/to/manifest.csv")
 `create_manifest` when you want the table on its own or want to grow it over
 multiple runs.)
 
+### Performance
+
+Both `create_manifest` and `write_per_roi` parallelise across series, and
+auto-tune per-ROI rasterisation threads so a single series with many ROIs still
+uses your spare cores. You can also set it explicitly — useful when calling
+`get_images_and_mask()` directly on one big multi-ROI series:
+
+```python
+reader = DicomReaderWriter(Contour_Names=[...], mask_thread_count=4)
+```
+
+`mask_thread_count=1` (the default) is the serial path; the parallel path
+produces byte-identical masks.
+
 ## Cross-tool evaluation
 
 The [`evaluation/`](evaluation/) directory contains an opt-in harness that

--- a/README.md
+++ b/README.md
@@ -22,142 +22,143 @@ pip install "DicomRTTool[viewer]"
 
 **Supported Python versions:** 3.10, 3.11, 3.12, 3.13.
 
-## Quick Start
+## Getting started: a typical workflow
+
+A first pass through a new DICOM corpus usually moves from **discover →
+survey → select → export**:
+
+1. **Discover** — walk the folder tree and list the ROIs that are present.
+2. **Survey** — write a metadata manifest of everything found (spacing + ROI volumes).
+3. **Select** — choose the ROIs you want and map their name aliases.
+4. **Export** — write NIfTI files, resampled to your target voxel spacing.
+
+Everything else in this README (loading a single series into NumPy, writing
+predictions back to RT structures, anonymization, performance tuning, …) builds
+on these four steps and is covered afterwards.
+
+### Step 1 — Discover: walk the folders
+
+`walk_through_folders` recursively scans a directory tree, groups files by
+`SeriesInstanceUID`, and links each RT structure and dose to its image series.
+The images and RT files do **not** need to live in the same folder.
 
 ```python
-from pathlib import Path
+from DicomRTTool.ReaderWriter import DicomReaderWriter
 
-from DicomRTTool.ReaderWriter import DicomReaderWriter, ROIAssociationClass
+reader = DicomReaderWriter()
+reader.walk_through_folders("/path/to/dicom")
 
-dicom_path = Path("/path/to/dicom")
-reader = DicomReaderWriter(description="Examples", arg_max=True)
-reader.walk_through_folders(dicom_path)
-
-# Inspect available ROIs.
+# What ROIs exist across everything that was found?
 all_rois = reader.return_rois(print_rois=True)
+```
 
-# Define target ROIs with optional name aliases.
-contour_names = ["tumor"]
-associations = [ROIAssociationClass("tumor", ["tumor_mr", "tumor_ct"])]
+### Step 2 — Survey: write a metadata manifest
+
+Before committing to an export, get a one-row-per-series overview with
+`create_manifest`. With no ROIs selected yet it records **every ROI it found**,
+so you can see what is available and how large each structure is:
+
+```python
+reader.create_manifest("/path/to/manifest.csv")
+```
+
+Each row holds the identifiers, the image spacing (`spacing_x/y/z`), and one
+`<roi> cc` column per ROI giving its mask volume in cubic centimetres (`-1`
+when that ROI is absent from the series). Add `anonymize=True,
+salt="MyProjectSalt"` to write only hashed identifiers. Re-runs **extend the
+file in place** rather than overwriting it (see
+[Incremental manifests](#incremental-manifests)), so you can keep growing one
+manifest as you walk more data.
+
+### Step 3 — Select: choose ROIs and map aliases
+
+Real-world ROI names are inconsistent (`Lung_L`, `Lung-Left`, `left lung`).
+`ROIAssociationClass` maps any number of aliases onto one canonical name, and
+`set_contour_names_and_associations` picks the ROIs you actually want:
+
+```python
+from DicomRTTool.ReaderWriter import ROIAssociationClass
+
 reader.set_contour_names_and_associations(
-    contour_names=contour_names,
-    associations=associations,
+    contour_names=["lung_l", "lung_r", "cord"],
+    associations=[
+        ROIAssociationClass("lung_l", ["lung-left", "left lung"]),
+        ROIAssociationClass("lung_r", ["lung-right", "right lung"]),
+        ROIAssociationClass("cord", ["spinal cord", "spinalcord"]),
+    ],
 )
 
-# Load images and masks for the first index that contains all target ROIs.
-reader.set_index(reader.indexes_with_contours[0])
-reader.get_images_and_mask()
-
-image_numpy   = reader.ArrayDicom          # NumPy image array
-mask_numpy    = reader.mask                # NumPy mask array
-image_handle  = reader.dicom_handle        # SimpleITK Image
-mask_handle   = reader.annotation_handle   # SimpleITK Image
+# Which series contain the selected ROIs?
+print(reader.indexes_with_contours)
 ```
 
-## Reading extra DICOM tags
+ROI names are matched case-insensitively. Build the reader with
+`require_all_contours=False` to also include series that carry only *some* of
+the selected ROIs.
+
+### Step 4 — Export: NIfTI with voxel resampling
+
+`write_per_roi` writes every selected series to a tidy per-case tree — one file
+per ROI — plus a `manifest.csv`. Pass `output_spacing` (mm) to resample on the
+way out: **linear** interpolation for the image and dose, **nearest-neighbour**
+for masks (labels are never blended). The dose is resampled onto the resampled
+image grid, so the image, masks, and dose all come out the same size and
+geometry.
 
 ```python
-from pydicom.tag import Tag
-
-plan_keys  = {"MyNamedRTPlan": Tag((0x300a, 0x002))}
-image_keys = {"MyPatientName": "0010|0010"}
-
-reader = DicomReaderWriter(
-    description="Examples",
-    arg_max=True,
-    plan_pydicom_string_keys=plan_keys,
-    image_sitk_string_keys=image_keys,
+# Build with get_dose_output=True if you also want the dose loaded/resampled.
+reader.write_per_roi(
+    "/path/to/out",
+    output_spacing=(1.0, 1.0, 3.0),     # omit to keep native spacing
+    anonymize=True, salt="MyProjectSalt",
 )
 ```
-
-## Resetting state between uses
-
-`DicomReaderWriter` instances can be reused across multiple corpora; call
-the appropriate reset method before walking a fresh folder tree or
-swapping target ROIs:
-
-```python
-reader.reset()        # wipe everything (images, RTs, masks, cached UIDs)
-reader.reset_rts()    # clear ROI bookkeeping only; keep loaded images
-reader.reset_mask()   # re-allocate an empty mask after changing Contour_Names
-```
-
-## Writing predictions back to an RT structure
-
-```python
-import numpy as np
-
-# 4-channel one-hot prediction matching the loaded image shape:
-# (slices, rows, cols, num_classes + 1) — channel 0 is background.
-predictions = np.zeros((*reader.ArrayDicom.shape, 3), dtype=np.float32)
-# ... populate `predictions` from your model ...
-
-reader.prediction_array_to_RT(
-    prediction_array=predictions,
-    output_dir="/path/to/output",
-    ROI_Names=["organ_a", "organ_b"],
-)
-```
-
-## Bulk export to a per-ROI NIfTI layout
-
-`write_per_roi` converts every indexed series-with-contours into a tidy,
-per-case folder tree — one file per ROI — plus a single `manifest.csv`
-(one row per series). No persistent iteration index is maintained. This
-mirrors the layout used by the companion C# DICOM→NIfTI tool:
 
 ```text
 out/
-  <case_id>/
+  <case_id>/                 # series hash when anonymized, else <patient>_<series>
     image.nii.gz
     masks/
-      tumor.nii.gz
+      lung_l.nii.gz
+      lung_r.nii.gz
       cord.nii.gz
-    doses/                 # only when get_dose_output=True and dose exists
+    doses/                   # only when get_dose_output=True and dose exists
       plan.nii.gz
-  manifest.csv             # patient/study/series ids, spacing, per-ROI volume (cc)
+  manifest.csv               # identifiers, spacing, per-ROI volume (cc)
+  anonymization_key.json     # only when anonymize=True (reverse lookup)
 ```
+
+This layout mirrors the companion C# DICOM→NIfTI tool. The `manifest.csv` has
+the same shape as the one from [Step 2](#step-2--survey-write-a-metadata-manifest).
+
+---
+
+That's the core loop. The sections below are reference material for everything
+else.
+
+## Load a single series into NumPy / SimpleITK
+
+For in-memory analysis (e.g. feeding a model) instead of exporting files, load
+one series directly:
 
 ```python
-reader = DicomReaderWriter(
-    description="export",
-    Contour_Names=["tumor", "cord"],
-    require_all_contours=False,   # a series may carry only some ROIs (others -> -1)
-)
-reader.walk_through_folders("/path/to/dicom")
-reader.write_per_roi("/path/to/out")
+reader.set_index(reader.indexes_with_contours[0])
+reader.get_images_and_mask()
+
+image_numpy  = reader.ArrayDicom         # NumPy image array
+mask_numpy   = reader.mask               # NumPy mask array
+image_handle = reader.dicom_handle       # SimpleITK Image
+mask_handle  = reader.annotation_handle  # SimpleITK Image
 ```
 
-Each manifest row records the patient/study/series identifiers, the output
-spacing, and the mask volume in cc for every requested ROI (`-1` when an ROI
-is absent from that series).
+## Anonymized export
 
-### Resampling outputs to a target spacing
-
-Pass an `output_spacing` tuple (mm) to resample on the way out. Images and
-dose are resampled with **linear** interpolation, masks with
-**nearest-neighbour** so labels are never blended. The dose is resampled onto
-the **resampled image grid**, so the image, masks, and dose all come out the
-same size and geometry. The same option is available on the single-series
-writer `write_images_annotations`:
-
-```python
-reader.write_per_roi("/path/to/out", output_spacing=(1.0, 1.0, 3.0))
-reader.write_images_annotations("/path/to/out", output_spacing=(1.0, 1.0, 3.0))
-
-# Or resample any SimpleITK handle directly:
-from DicomRTTool import resample_to_spacing
-resampled = resample_to_spacing(reader.dicom_handle, (1.0, 1.0, 3.0), "Linear")
-```
-
-### Anonymized export
-
-With `anonymize=True`, identifiers are replaced by deterministic SHA-256
-hashes (patient MRN → patient hash, study hash, series hash), the case folder
-is named by the series hash, and an `anonymization_key.json` reverse-lookup
-file is written alongside the manifest. The hashing matches the companion C#
-tool byte-for-byte, so the two tools produce identical hashes for the same
-salt:
+`anonymize=True` (on `write_per_roi` or `create_manifest`) replaces identifiers
+with deterministic SHA-256 hashes (patient MRN → patient hash, study hash,
+series hash). For `write_per_roi` the case folder is named by the series hash
+and an `anonymization_key.json` reverse-lookup file is written alongside the
+manifest. The hashing matches the companion C# tool byte-for-byte, so both
+tools produce identical hashes for the same salt:
 
 ```python
 reader.write_per_roi("/path/to/out", anonymize=True, salt="MyProjectSalt")
@@ -167,40 +168,18 @@ from DicomRTTool import hash_patient, hash_study, hash_series, AnonymizationKey
 hash_patient("1234567")          # -> 'P...'  (prefix + 5 bytes of SHA-256)
 ```
 
-## Metadata manifest (`create_manifest`)
+## Metadata manifest details
 
-When you only want the metadata table — **not** the NIfTI files —
-`create_manifest` writes a single CSV that mirrors the companion C# tool's
-`export_manifest.csv`: one row per series-with-contours, with the image
-spacing and the mask volume (cc) of every ROI. It records, per series:
-
-- the identifiers (`patient_hash`, `study_hash`, `series_hash`, and the raw
-  `PatientID` / `StudyInstanceUID` / `SeriesInstanceUID` unless `anonymize=True`);
-- the image spacing (`spacing_x`, `spacing_y`, `spacing_z`);
-- one `<roi> cc` column per ROI name — the mask volume in cubic centimetres,
-  or `-1` when that ROI is absent from the series.
-
-If you don't set `Contour_Names` (and don't pass `rois=`), `create_manifest`
-records **every ROI discovered during the walk** — so the simplest case just
-works:
-
-```python
-reader = DicomReaderWriter(description="manifest")
-reader.walk_through_folders("/path/to/dicom")
-reader.create_manifest("/path/to/manifest.csv")   # one column per discovered ROI
-
-# Anonymized identifiers only:
-reader.create_manifest("/path/to/manifest.csv", anonymize=True, salt="MyProjectSalt")
-```
-
-To restrict the manifest to specific ROIs, either set `Contour_Names` on the
-reader or pass them explicitly:
+`create_manifest` ([Step 2](#step-2--survey-write-a-metadata-manifest)) defaults
+to **every ROI discovered during the walk**. To restrict it to specific ROIs,
+either set `Contour_Names` on the reader (as in
+[Step 3](#step-3--select-choose-rois-and-map-aliases)) or pass them explicitly:
 
 ```python
 reader.create_manifest("/path/to/manifest.csv", rois=["tumor", "cord"])
 ```
 
-### Incremental updates (resumes an existing file)
+### Incremental manifests
 
 If the target CSV already exists, `create_manifest` **reads it and extends it
 in place** instead of overwriting. Series already recorded (matched by
@@ -225,7 +204,67 @@ reader.create_manifest("/path/to/manifest.csv")
 `create_manifest` when you want the table on its own or want to grow it over
 multiple runs.)
 
-### Performance
+## Resampling any SimpleITK handle
+
+The resampling helpers used by the writers are exported for direct use:
+
+```python
+from DicomRTTool import resample_to_spacing, resample_to_reference
+
+# To a target voxel spacing (linear for images/dose, "Nearest" for masks):
+resampled = resample_to_spacing(reader.dicom_handle, (1.0, 1.0, 3.0), "Linear")
+
+# Onto another image's exact grid (size/spacing/origin/direction):
+dose_on_image = resample_to_reference(reader.dose_handle, resampled, "Linear")
+```
+
+`write_images_annotations` also accepts `output_spacing` for the single-series
+combined-file output (`Overall_Data_*` / `Overall_mask_*` / `Overall_dose_*`).
+
+## Writing predictions back to an RT structure
+
+```python
+import numpy as np
+
+# 4-channel one-hot prediction matching the loaded image shape:
+# (slices, rows, cols, num_classes + 1) — channel 0 is background.
+predictions = np.zeros((*reader.ArrayDicom.shape, 3), dtype=np.float32)
+# ... populate `predictions` from your model ...
+
+reader.prediction_array_to_RT(
+    prediction_array=predictions,
+    output_dir="/path/to/output",
+    ROI_Names=["organ_a", "organ_b"],
+)
+```
+
+## Reading extra DICOM tags
+
+```python
+from pydicom.tag import Tag
+
+plan_keys  = {"MyNamedRTPlan": Tag((0x300a, 0x002))}
+image_keys = {"MyPatientName": "0010|0010"}
+
+reader = DicomReaderWriter(
+    plan_pydicom_string_keys=plan_keys,
+    image_sitk_string_keys=image_keys,
+)
+```
+
+## Resetting state between uses
+
+`DicomReaderWriter` instances can be reused across multiple corpora; call the
+appropriate reset method before walking a fresh folder tree or swapping target
+ROIs:
+
+```python
+reader.reset()        # wipe everything (images, RTs, masks, cached UIDs)
+reader.reset_rts()    # clear ROI bookkeeping only; keep loaded images
+reader.reset_mask()   # re-allocate an empty mask after changing Contour_Names
+```
+
+## Performance
 
 Both `create_manifest` and `write_per_roi` parallelise across series, and
 auto-tune per-ROI rasterisation threads so a single series with many ROIs still
@@ -257,11 +296,14 @@ external dataset and the built C# binary.
 - **`create_manifest`** — write (or incrementally extend) a metadata-only CSV
   of per-series image spacing and per-ROI volumes, mirroring the C# manifest.
 - **Output resampling** — `output_spacing` on `write_per_roi` and
-  `write_images_annotations`, plus the public `resample_to_spacing` helper
-  (linear for image/dose, nearest-neighbour for masks).
+  `write_images_annotations`, plus the public `resample_to_spacing` /
+  `resample_to_reference` helpers (linear for image/dose, nearest-neighbour for
+  masks; dose lands on the resampled image grid).
 - **Anonymization** — deterministic SHA-256 hashing (`hash_patient` /
   `hash_study` / `hash_series` / `AnonymizationKey`) for anonymized exports,
   matching the companion C# tool.
+- **Faster, parallel rasterisation** — `mask_thread_count` plus the removal of
+  a per-ROI full-array rescan (~2.4× on multi-ROI series).
 - **Cross-tool evaluation harness** under `evaluation/`.
 
 ## What's new in v4.0

--- a/evaluation/README.md
+++ b/evaluation/README.md
@@ -1,0 +1,63 @@
+# Cross-tool evaluation: DicomRTTool (Python) vs DicomRtNifti.Cli (C#)
+
+This harness runs **both** converters live on a handful of TCIA LCTSC
+patients and compares their NIfTI outputs in physical space. It is *not* part
+of the hermetic test suite — it needs the external LCTSC corpus and a built
+C# `DicomRtNifti.Cli.exe`.
+
+## What it compares
+
+| Comparison | C# command | Python feature | Metrics |
+|---|---|---|---|
+| **Mask generation** | `--forward` (per-ROI masks) | `write_per_roi` masks | Dice, volume (cc) agreement |
+| **Image generation** | `--image-forward` | per-ROI `image.nii.gz` | voxel mean-abs-error, size/spacing |
+| **Resampling** | `--image-forward --target-spacing X,Y,Z` | `write_per_roi(output_spacing=…)` | voxel MAE, size/spacing |
+
+Both tools are run on identical, short-path-staged inputs (TCIA's deeply
+nested UID folders exceed the Windows 260-char path limit, so each patient's
+series are copied into a temporary short directory first). Outputs are
+compared after resampling onto a common grid, so geometry/orientation
+differences don't confound the metrics.
+
+### Expected results
+
+The two tools use **different polygon-boundary conventions** — DicomRTTool is
+boundary-inclusive, the C# tool fills the polygon interior — so masks are
+*not* byte-identical. The goal is to confirm the outputs agree within that
+expected tolerance ("output makes sense"):
+
+- **Masks:** median Dice ≈ 0.99 for large OARs (heart, lungs); lower
+  (≈ 0.90–0.93) for thin structures (esophagus, spinal cord). The C# volumes
+  run slightly smaller (interior-of-polygon).
+- **Native images:** MAE ≈ 0.0 — both read the same DICOM via SimpleITK.
+- **Resample parity:** MAE ≈ 0.4 HU — sub-voxel grid differences only.
+
+## Running
+
+```bash
+python evaluation/compare_with_csharp.py \
+    --dataset   "C:/.../Dicom_RT_Images_Csharp/PythonCode/datasets/v2/lctsc" \
+    --csharp-exe "C:/.../DicomRtNifti.Cli/bin/Release/net8.0/win-x64/DicomRtNifti.Cli.exe" \
+    --out-dir    ./eval_out \
+    --num-patients 10 \
+    --target-spacing 3,3,3
+```
+
+Writes `masks.csv`, `images.csv`, `resample.csv`, and `errors.csv` into
+`--out-dir` and prints a summary. Pass `--keep-outputs` to also copy each
+patient's NIfTI outputs into the output directory for inspection.
+
+## As a pytest (opt-in)
+
+`tests/test_csharp_parity.py` runs the same comparison and asserts tolerant
+thresholds. It **auto-skips** unless both environment variables are set:
+
+```bash
+export DICOMRTTOOL_LCTSC_DIR="C:/.../PythonCode/datasets/v2/lctsc"
+export DICOMRTTOOL_CSHARP_EXE="C:/.../win-x64/DicomRtNifti.Cli.exe"
+export DICOMRTTOOL_PARITY_N=2          # optional, patient count (default 2)
+python -m pytest tests/test_csharp_parity.py -v
+```
+
+Because it auto-skips, the normal `pytest` run and CI never need the external
+dataset or the C# binary.

--- a/evaluation/__init__.py
+++ b/evaluation/__init__.py
@@ -1,0 +1,6 @@
+"""Cross-tool evaluation harness (DicomRTTool vs the C# DicomRtNifti.Cli tool).
+
+Not part of the installed package — these modules live alongside the repo for
+running comparisons against the external LCTSC corpus and a built C# binary.
+See ``README.md`` in this directory.
+"""

--- a/evaluation/compare_with_csharp.py
+++ b/evaluation/compare_with_csharp.py
@@ -1,0 +1,75 @@
+"""CLI: compare DicomRTTool (Python) against the C# DicomRtNifti.Cli tool.
+
+Example::
+
+    python evaluation/compare_with_csharp.py \
+        --dataset "C:/.../Dicom_RT_Images_Csharp/PythonCode/datasets/v2/lctsc" \
+        --csharp-exe "C:/.../DicomRtNifti.Cli/bin/Release/net8.0/win-x64/DicomRtNifti.Cli.exe" \
+        --out-dir ./eval_out \
+        --num-patients 10 \
+        --target-spacing 3,3,3
+
+Writes ``masks.csv``, ``images.csv``, ``resample.csv`` and ``errors.csv`` into
+``--out-dir`` and prints a summary. See ``evaluation/README.md``.
+"""
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+
+# Allow running as a plain script (``python evaluation/compare_with_csharp.py``).
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from evaluation.csharp_eval import evaluate, summarize, write_csv
+
+
+def _parse_spacing(text: str) -> tuple[float, float, float]:
+    parts = [p.strip() for p in text.split(",")]
+    if len(parts) != 3:
+        raise argparse.ArgumentTypeError("--target-spacing expects 'X,Y,Z'")
+    values = tuple(float(p) for p in parts)
+    if any(v <= 0 for v in values):
+        raise argparse.ArgumentTypeError("--target-spacing components must be positive")
+    return values  # type: ignore[return-value]
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--dataset", required=True, help="LCTSC patient-root directory (datasets/v2/lctsc).")
+    parser.add_argument("--csharp-exe", required=True, help="Path to DicomRtNifti.Cli.exe.")
+    parser.add_argument("--out-dir", default="./eval_out", help="Where to write the result CSVs.")
+    parser.add_argument("--num-patients", type=int, default=10, help="How many patients to compare.")
+    parser.add_argument("--target-spacing", type=_parse_spacing, default=(3.0, 3.0, 3.0),
+                        help="Resample spacing for the resample-parity comparison (mm).")
+    parser.add_argument("--keep-outputs", action="store_true", help="Copy per-patient NIfTI outputs into out-dir.")
+    args = parser.parse_args(argv)
+
+    if not os.path.isdir(args.dataset):
+        parser.error(f"--dataset not found: {args.dataset}")
+    if not os.path.isfile(args.csharp_exe):
+        parser.error(f"--csharp-exe not found: {args.csharp_exe}")
+
+    result = evaluate(
+        dataset_dir=args.dataset,
+        csharp_exe=args.csharp_exe,
+        work_dir=args.out_dir,
+        num_patients=args.num_patients,
+        target_spacing=args.target_spacing,
+        keep_outputs=args.keep_outputs,
+    )
+
+    os.makedirs(args.out_dir, exist_ok=True)
+    write_csv(result.mask_rows, os.path.join(args.out_dir, "masks.csv"))
+    write_csv(result.image_rows, os.path.join(args.out_dir, "images.csv"))
+    write_csv(result.resample_rows, os.path.join(args.out_dir, "resample.csv"))
+    write_csv(result.errors, os.path.join(args.out_dir, "errors.csv"))
+
+    print("\n=== C# vs Python evaluation ===")
+    print(summarize(result))
+    print(f"\nCSVs written to: {os.path.abspath(args.out_dir)}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/evaluation/csharp_eval.py
+++ b/evaluation/csharp_eval.py
@@ -1,0 +1,397 @@
+"""Cross-tool evaluation: DicomRTTool (Python) vs the C# DicomRtNifti.Cli tool.
+
+Runs *both* converters live on a handful of TCIA LCTSC patients and compares
+their NIfTI outputs in physical space:
+
+* **mask generation** — C# ``--forward`` per-ROI masks vs Python
+  ``DicomReaderWriter.write_per_roi`` masks (Dice, volume agreement);
+* **image generation** — C# ``--image-forward`` image vs the Python image
+  (voxel mean-absolute-error, geometry);
+* **resampling** — C# ``--image-forward --target-spacing X,Y,Z`` vs the Python
+  resample feature (``write_per_roi(output_spacing=...)``).
+
+The two tools use different polygon-boundary conventions (DicomRTTool is
+boundary-inclusive; the C# tool fills the polygon interior), so masks are
+*not* expected to be byte-identical — the goal is to confirm the outputs agree
+within the expected boundary-convention tolerance ("output makes sense").
+
+Nothing here runs under the normal hermetic test suite; it requires the
+external LCTSC corpus and a built ``DicomRtNifti.Cli.exe``. See
+``compare_with_csharp.py`` for the CLI entry point and ``README.md``.
+"""
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import tempfile
+from dataclasses import dataclass, field
+from pathlib import Path
+
+import numpy as np
+import SimpleITK as sitk
+
+from DicomRTTool.ReaderWriter import DicomReaderWriter, ROIAssociationClass
+
+# The five LCTSC organs-at-risk (canonical names == the C# reference filenames).
+LCTSC_OARS = ["esophagus", "heart", "lung_l", "lung_r", "spinalcord"]
+
+# A few tolerant aliases so non-standard ROI names still line up.
+LCTSC_ASSOCIATIONS = [
+    ROIAssociationClass("lung_l", ["lung_l", "lung-left", "left lung", "lung_left", "lung left"]),
+    ROIAssociationClass("lung_r", ["lung_r", "lung-right", "right lung", "lung_right", "lung right"]),
+    ROIAssociationClass("spinalcord", ["spinalcord", "spinal cord", "spinal_cord", "cord"]),
+    ROIAssociationClass("esophagus", ["esophagus", "oesophagus"]),
+    ROIAssociationClass("heart", ["heart"]),
+]
+
+
+# ---------------------------------------------------------------------------
+# Long-path helpers (TCIA UID folders blow past Windows MAX_PATH of 260)
+# ---------------------------------------------------------------------------
+
+def _ext(path: str | os.PathLike) -> str:
+    """Return an extended-length (``\\\\?\\``) absolute path on Windows."""
+    p = os.path.abspath(os.fspath(path))
+    if os.name == "nt" and not p.startswith("\\\\?\\"):
+        return "\\\\?\\" + p
+    return p
+
+
+# ---------------------------------------------------------------------------
+# Input discovery + staging
+# ---------------------------------------------------------------------------
+
+@dataclass
+class PatientInputs:
+    patient_id: str
+    image_folder: str   # short, staged: contains only CT/MR slices
+    rtstruct_path: str   # short, staged: the RTSTRUCT file
+
+
+def _classify(path: str) -> tuple[str | None, int | None]:
+    """Return ``(modality, n_files_hint)`` for a DICOM file, or ``(None, None)``."""
+    try:
+        import pydicom
+
+        ds = pydicom.dcmread(path, stop_before_pixels=True, force=True)
+        return getattr(ds, "Modality", None), None
+    except Exception:
+        return None, None
+
+
+def stage_patient(patient_dir: str, stage_root: str) -> PatientInputs | None:
+    """Copy a TCIA patient's series into short paths and classify them.
+
+    Every ``.dcm`` under *patient_dir* is copied (with ``\\\\?\\`` long-path
+    reads) into ``stage_root/series_<i>/`` so downstream tools never see a path
+    over 260 chars. The CT/MR series folder with the most slices becomes the
+    image folder; the lone RTSTRUCT file is located and returned.
+    """
+    patient_id = os.path.basename(patient_dir.rstrip("\\/"))
+    walk_root = _ext(patient_dir)
+
+    series_dirs: dict[str, list[str]] = {}
+    for dirpath, _dirnames, filenames in os.walk(walk_root):
+        dcm_files = [f for f in filenames if f.lower().endswith(".dcm")]
+        if dcm_files:
+            series_dirs[dirpath] = dcm_files
+
+    if not series_dirs:
+        return None
+
+    os.makedirs(stage_root, exist_ok=True)
+    image_folder: str | None = None
+    image_count = -1
+    rtstruct_path: str | None = None
+
+    for i, (src_dir, files) in enumerate(sorted(series_dirs.items())):
+        dst_dir = os.path.join(stage_root, f"series_{i}")
+        os.makedirs(dst_dir, exist_ok=True)
+        modalities: list[str] = []
+        for fname in files:
+            src = os.path.join(src_dir, fname)
+            dst = os.path.join(dst_dir, fname)
+            shutil.copyfile(_ext(src), dst)
+            mod, _ = _classify(dst)
+            if mod:
+                modalities.append(mod)
+
+        if "RTSTRUCT" in modalities:
+            # RTSTRUCT series: usually a single file.
+            for fname in files:
+                cand = os.path.join(dst_dir, fname)
+                mod, _ = _classify(cand)
+                if mod == "RTSTRUCT":
+                    rtstruct_path = cand
+                    break
+        else:
+            n_image = sum(1 for m in modalities if m in ("CT", "MR", "PT"))
+            if n_image > image_count:
+                image_count = n_image
+                image_folder = dst_dir
+
+    if not image_folder or not rtstruct_path:
+        return None
+    return PatientInputs(patient_id, image_folder, rtstruct_path)
+
+
+def list_patients(dataset_dir: str, limit: int) -> list[str]:
+    """Return up to *limit* patient directories under *dataset_dir*, sorted."""
+    entries = sorted(
+        os.path.join(dataset_dir, d)
+        for d in os.listdir(dataset_dir)
+        if os.path.isdir(os.path.join(dataset_dir, d))
+    )
+    return entries[:limit]
+
+
+# ---------------------------------------------------------------------------
+# Running the two tools
+# ---------------------------------------------------------------------------
+
+def run_csharp_forward(exe: str, inputs: PatientInputs, out_dir: str) -> dict[str, str]:
+    """Run C# ``--forward``; return ``{roi_lower: mask_path}``."""
+    os.makedirs(out_dir, exist_ok=True)
+    cmd = [
+        exe, "--forward",
+        "--rtstruct", inputs.rtstruct_path,
+        "--image-folder", inputs.image_folder,
+        "--output-folder", out_dir,
+    ]
+    subprocess.run(cmd, check=True, capture_output=True, text=True)
+    return {
+        p.name[:-7].lower(): str(p)             # strip ".nii.gz"
+        for p in Path(out_dir).glob("*.nii.gz")
+        if p.name.lower() != "image.nii.gz"
+    }
+
+
+def run_csharp_image_forward(
+    exe: str,
+    inputs: PatientInputs,
+    out_path: str,
+    target_spacing: tuple[float, float, float] | None = None,
+) -> str:
+    """Run C# ``--image-forward`` (optionally resampled); return the NIfTI path."""
+    os.makedirs(os.path.dirname(out_path), exist_ok=True)
+    cmd = [
+        exe, "--image-forward",
+        "--image-folder", inputs.image_folder,
+        "--output", out_path,
+    ]
+    if target_spacing is not None:
+        cmd += ["--target-spacing", ",".join(str(s) for s in target_spacing)]
+    subprocess.run(cmd, check=True, capture_output=True, text=True)
+    return out_path
+
+
+def run_python_export(
+    inputs: PatientInputs,
+    out_dir: str,
+    output_spacing: tuple[float, float, float] | None = None,
+) -> tuple[str, dict[str, str]]:
+    """Run the Python per-ROI export; return ``(image_path, {roi: mask_path})``."""
+    reader = DicomReaderWriter(
+        description="eval",
+        Contour_Names=LCTSC_OARS,
+        associations=LCTSC_ASSOCIATIONS,
+        arg_max=False,
+        verbose=False,
+        require_all_contours=False,
+    )
+    # Walk the staged patient root (image folder + rtstruct are siblings).
+    walk_root = os.path.dirname(inputs.image_folder)
+    reader.walk_through_folders(walk_root, thread_count=1)
+    reader.write_per_roi(out_dir, output_spacing=output_spacing, thread_count=1)
+
+    case_dirs = [p for p in Path(out_dir).iterdir() if p.is_dir()]
+    if not case_dirs:
+        raise RuntimeError(f"Python export produced no case folder in {out_dir}")
+    case = case_dirs[0]
+    masks = {p.name[:-7].lower(): str(p) for p in (case / "masks").glob("*.nii.gz")}
+    return str(case / "image.nii.gz"), masks
+
+
+# ---------------------------------------------------------------------------
+# Metrics (compared in physical space via resampling onto a common grid)
+# ---------------------------------------------------------------------------
+
+def _resample_like(moving: sitk.Image, reference: sitk.Image, interp: int) -> sitk.Image:
+    return sitk.Resample(moving, reference, sitk.Transform(), interp, 0.0, moving.GetPixelID())
+
+
+def binary_dice(a: np.ndarray, b: np.ndarray) -> float:
+    a_b = a.astype(bool)
+    b_b = b.astype(bool)
+    denom = int(a_b.sum()) + int(b_b.sum())
+    if denom == 0:
+        return 1.0
+    return 2.0 * int(np.logical_and(a_b, b_b).sum()) / denom
+
+
+def compare_masks(python_mask_path: str, csharp_mask_path: str) -> dict[str, float]:
+    """Dice + volume agreement between two binary masks (C# resampled onto Python grid)."""
+    py = sitk.ReadImage(python_mask_path)
+    cs = sitk.ReadImage(csharp_mask_path)
+    cs_on_py = _resample_like(cs, py, sitk.sitkNearestNeighbor)
+
+    py_a = sitk.GetArrayFromImage(py) > 0
+    cs_a = sitk.GetArrayFromImage(cs_on_py) > 0
+    voxel_cc = float(np.prod(py.GetSpacing())) / 1000.0
+    vol_py = float(py_a.sum()) * voxel_cc
+    vol_cs = float(cs_a.sum()) * voxel_cc
+    rel = abs(vol_py - vol_cs) / vol_cs if vol_cs > 0 else float("nan")
+    return {
+        "dice": round(binary_dice(py_a, cs_a), 4),
+        "volume_cc_python": round(vol_py, 3),
+        "volume_cc_csharp": round(vol_cs, 3),
+        "volume_rel_diff": round(rel, 4),
+    }
+
+
+def compare_images(python_image_path: str, csharp_image_path: str) -> dict[str, float]:
+    """Voxel agreement + geometry between two image volumes (C# resampled onto Python grid)."""
+    py = sitk.ReadImage(python_image_path)
+    cs = sitk.ReadImage(csharp_image_path)
+    cs_on_py = sitk.Cast(_resample_like(cs, py, sitk.sitkLinear), py.GetPixelID())
+
+    py_a = sitk.GetArrayFromImage(py).astype(np.float64)
+    cs_a = sitk.GetArrayFromImage(cs_on_py).astype(np.float64)
+    diff = np.abs(py_a - cs_a)
+    spacing_match = max(abs(a - b) for a, b in zip(py.GetSpacing(), cs.GetSpacing(), strict=False))
+    return {
+        "mean_abs_error": round(float(diff.mean()), 4),
+        "max_abs_error": round(float(diff.max()), 4),
+        "p99_abs_error": round(float(np.percentile(diff, 99)), 4),
+        "python_size": "x".join(str(s) for s in py.GetSize()),
+        "csharp_size": "x".join(str(s) for s in cs.GetSize()),
+        "spacing_max_abs_diff_mm": round(float(spacing_match), 4),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Orchestration
+# ---------------------------------------------------------------------------
+
+@dataclass
+class EvalResult:
+    mask_rows: list[dict] = field(default_factory=list)
+    image_rows: list[dict] = field(default_factory=list)
+    resample_rows: list[dict] = field(default_factory=list)
+    errors: list[dict] = field(default_factory=list)
+
+
+def evaluate(
+    dataset_dir: str,
+    csharp_exe: str,
+    work_dir: str,
+    num_patients: int = 10,
+    target_spacing: tuple[float, float, float] = (3.0, 3.0, 3.0),
+    keep_outputs: bool = False,
+) -> EvalResult:
+    """Run the full comparison over up to *num_patients* patients."""
+    result = EvalResult()
+    patients = list_patients(dataset_dir, num_patients)
+    os.makedirs(work_dir, exist_ok=True)
+
+    for patient_dir in patients:
+        pid = os.path.basename(patient_dir.rstrip("\\/"))
+        stage = tempfile.mkdtemp(prefix="rtmask_eval_")
+        try:
+            inputs = stage_patient(patient_dir, os.path.join(stage, "in"))
+            if inputs is None:
+                result.errors.append({"patient_id": pid, "stage": "stage", "error": "no CT+RTSTRUCT found"})
+                continue
+
+            cs_masks_dir = os.path.join(stage, "cs_masks")
+            py_native_dir = os.path.join(stage, "py_native")
+            cs_img = os.path.join(stage, "cs_img", "image.nii.gz")
+            cs_img_rs = os.path.join(stage, "cs_img_rs", "image.nii.gz")
+            py_resample_dir = os.path.join(stage, "py_resample")
+
+            # --- mask generation (native) ---
+            cs_masks = run_csharp_forward(csharp_exe, inputs, cs_masks_dir)
+            py_image, py_masks = run_python_export(inputs, py_native_dir)
+            for roi in sorted(set(py_masks) & set(cs_masks)):
+                row = {"patient_id": pid, "roi": roi}
+                row.update(compare_masks(py_masks[roi], cs_masks[roi]))
+                result.mask_rows.append(row)
+            for roi in sorted(set(py_masks) ^ set(cs_masks)):
+                result.errors.append({
+                    "patient_id": pid, "stage": "mask_match",
+                    "error": f"roi '{roi}' only in {'python' if roi in py_masks else 'csharp'}",
+                })
+
+            # --- image generation (native) ---
+            run_csharp_image_forward(csharp_exe, inputs, cs_img)
+            img_row = {"patient_id": pid}
+            img_row.update(compare_images(py_image, cs_img))
+            result.image_rows.append(img_row)
+
+            # --- resampling ---
+            run_csharp_image_forward(csharp_exe, inputs, cs_img_rs, target_spacing=target_spacing)
+            py_image_rs, _ = run_python_export(inputs, py_resample_dir, output_spacing=target_spacing)
+            rs_row = {"patient_id": pid, "target_spacing": ",".join(str(s) for s in target_spacing)}
+            rs_row.update(compare_images(py_image_rs, cs_img_rs))
+            result.resample_rows.append(rs_row)
+
+            if keep_outputs:
+                shutil.copytree(stage, os.path.join(work_dir, pid), dirs_exist_ok=True)
+        except subprocess.CalledProcessError as exc:
+            result.errors.append({
+                "patient_id": pid, "stage": "subprocess",
+                "error": (exc.stderr or str(exc))[-500:],
+            })
+        except Exception as exc:
+            result.errors.append({"patient_id": pid, "stage": "exception", "error": str(exc)})
+        finally:
+            shutil.rmtree(stage, ignore_errors=True)
+
+    return result
+
+
+def write_csv(rows: list[dict], path: str) -> None:
+    """Write a list of dict rows to CSV using the stdlib (no pandas needed)."""
+    import csv
+
+    if not rows:
+        Path(path).write_text("")
+        return
+    fieldnames: list[str] = []
+    for row in rows:
+        for key in row:
+            if key not in fieldnames:
+                fieldnames.append(key)
+    os.makedirs(os.path.dirname(os.path.abspath(path)), exist_ok=True)
+    with open(path, "w", newline="", encoding="utf-8") as handle:
+        writer = csv.DictWriter(handle, fieldnames=fieldnames)
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+def summarize(result: EvalResult) -> str:
+    """Return a short human-readable summary of the evaluation."""
+    lines = []
+    if result.mask_rows:
+        dices = [r["dice"] for r in result.mask_rows]
+        lines.append(
+            f"Masks: {len(result.mask_rows)} ROI comparisons | "
+            f"Dice mean={np.mean(dices):.4f} min={np.min(dices):.4f} "
+            f"median={np.median(dices):.4f}"
+        )
+    if result.image_rows:
+        mae = [r["mean_abs_error"] for r in result.image_rows]
+        lines.append(
+            f"Images (native): {len(result.image_rows)} | "
+            f"MAE mean={np.mean(mae):.4f} max={np.max(mae):.4f}"
+        )
+    if result.resample_rows:
+        mae = [r["mean_abs_error"] for r in result.resample_rows]
+        lines.append(
+            f"Resample parity: {len(result.resample_rows)} | "
+            f"MAE mean={np.mean(mae):.4f} max={np.max(mae):.4f}"
+        )
+    if result.errors:
+        lines.append(f"Errors/warnings: {len(result.errors)} (see errors.csv)")
+    return "\n".join(lines) if lines else "No comparisons produced."

--- a/src/DicomRTTool/ReaderWriter.py
+++ b/src/DicomRTTool/ReaderWriter.py
@@ -1618,15 +1618,33 @@ class DicomReaderWriter:
             output_path: CSV path to create or extend.
             anonymize: Write only the hashed identifiers (no raw IDs).
             salt: Salt for the deterministic identifier hashes.
-            rois: ROI names to record. Defaults to :attr:`Contour_Names`.
+            rois: ROI names to record. Defaults to :attr:`Contour_Names` when
+                set, otherwise every ROI discovered during the walk.
             thread_count: Number of parallel worker threads.
         """
-        wanted_rois = [r.lower() for r in (rois if rois is not None else self.Contour_Names)]
+        # ROIs to record: explicit ``rois=``, else ``Contour_Names``, else
+        # *every* ROI discovered during the walk (matches the C# manifest, which
+        # records all ROIs it finds). Defaulting to all ROIs means a plain
+        # ``walk_through_folders`` -> ``create_manifest`` call "just works"
+        # without first calling ``set_contour_names_and_associations``.
+        if rois is not None:
+            wanted_rois = [r.lower() for r in rois]
+        elif self.Contour_Names:
+            wanted_rois = list(self.Contour_Names)
+        else:
+            wanted_rois = [r.lower() for r in self.all_rois]
         if not wanted_rois:
-            logger.warning("No ROIs to record. Set Contour_Names or pass rois=...")
+            logger.warning("No ROIs found to record. Walk a folder containing RT structures first.")
             return
-        if not self.indexes_with_contours:
-            logger.warning("No indexes with contours found; manifest not written.")
+
+        # Every series that carries at least one RT structure (independent of
+        # ``indexes_with_contours``, which is gated by ``Contour_Names``).
+        candidates = [
+            idx for idx, entry in self.series_instances_dictionary.items()
+            if entry.SeriesInstanceUID is not None and entry.RTs
+        ]
+        if not candidates:
+            logger.warning("No series with RT structures found; manifest not written.")
             return
 
         # Load any existing manifest so we only append genuinely new series.
@@ -1640,18 +1658,21 @@ class DicomReaderWriter:
 
         # Skip series already present (cheap -- no image load needed).
         todo: list[int] = []
-        for index in self.indexes_with_contours:
+        for index in candidates:
             entry = self.series_instances_dictionary[index]
             series_uid = entry.SeriesInstanceUID or ""
             if series_uid in existing_keys or hash_series(series_uid, salt) in existing_keys:
                 continue
             todo.append(index)
 
+        # The worker rasterises masks for exactly the ROIs we record (not the
+        # parent's possibly-empty ``Contour_Names``), so volumes are populated
+        # even when the caller never set contour names.
         key_dict = {
             "series_instances_dictionary": self.series_instances_dictionary,
             "associations": self.associations, "arg_max": self.arg_max,
             "require_all_contours": self.require_all_contours,
-            "Contour_Names": self.Contour_Names, "description": self.description,
+            "Contour_Names": wanted_rois, "description": self.description,
             "get_dose_output": self.get_dose_output,
         }
 

--- a/src/DicomRTTool/ReaderWriter.py
+++ b/src/DicomRTTool/ReaderWriter.py
@@ -86,6 +86,24 @@ def _sanitize_filename(name: str) -> str:
     return cleaned
 
 
+# Cap per-ROI rasterisation threads: past ~4 the GIL-bound parts dominate and
+# returns diminish (8 threads measured slower than 4).
+_MAX_MASK_THREADS = 4
+
+
+def _mask_threads_for(total_workers: int, n_series: int) -> int:
+    """Split a thread budget between series-level and per-ROI parallelism.
+
+    When many series are processed at once, series-level parallelism already
+    saturates the cores, so each series rasterises serially (1). When only a
+    few series are processed (e.g. a single multi-ROI series), the leftover
+    cores are handed to per-ROI rasterisation inside ``get_mask``.
+    """
+    if n_series <= 0:
+        return 1
+    return max(1, min(_MAX_MASK_THREADS, total_workers // n_series))
+
+
 # ---------------------------------------------------------------------------
 # ROI association helper (public API — kept here intentionally)
 # ---------------------------------------------------------------------------
@@ -182,6 +200,7 @@ class DicomReaderWriter:
         image_sitk_string_keys: SitkDicomKeys | None = None,
         dose_sitk_string_keys: SitkDicomKeys | None = None,
         group_dose_by_frame_of_reference: bool = True,
+        mask_thread_count: int = 1,
     ) -> None:
         # Logging setup
         if verbose:
@@ -191,6 +210,10 @@ class DicomReaderWriter:
         self.roi_class_list: list[ROIClass] = []
         self.dose: np.ndarray | None = None
         self.group_dose_by_frame_of_reference = group_dose_by_frame_of_reference
+        # Per-ROI rasterisation threads inside get_mask(). 1 = serial (default).
+        # The bulk writers auto-tune this so per-ROI threads only spin up when
+        # there are spare cores not already used by series-level parallelism.
+        self.mask_thread_count = mask_thread_count
         self.verbose = verbose
         self.annotation_handle: sitk.Image | None = None
         self.dicom_handle: sitk.Image | None = None
@@ -935,14 +958,41 @@ class DicomReaderWriter:
             logger.info("Loading images for index %d (mask requested)", self.index)
             self.get_images()
 
+        channel_of = {name: i + 1 for i, name in enumerate(self.Contour_Names)}
         for _rt_key, rt in entry.RTs.items():
+            # Warm the RT-struct cache once (serial) so the per-ROI workers below
+            # only ever *read* self.RS_struct / self.structure_references.
+            self._characterize_rt(rt)
+            jobs: list[tuple[int, str, int]] = []
             for roi_name in rt.ROIs_In_Structure:
                 true_name = self._resolve_roi_name(roi_name)
                 if true_name and true_name in self.Contour_Names:
-                    mask = self._return_mask_for_roi(rt, roi_name)
-                    ch = self.Contour_Names.index(true_name) + 1
-                    self.mask[..., ch] += mask
-                    self.mask[self.mask > 1] = 1
+                    struct_idx = self.structure_references[rt.ROIs_In_Structure[roi_name].ROINumber]
+                    jobs.append((struct_idx, roi_name, channel_of[true_name]))
+            if not jobs:
+                continue
+
+            # Rasterise each ROI into its own array. The ROIs are independent and
+            # only read shared state, so this parallelises across ROIs; the heavy
+            # inner ops (SimpleITK transforms, cv2.fillPoly, numpy) release the
+            # GIL. ``mask_thread_count == 1`` keeps the legacy serial path.
+            def _raster(job: tuple[int, str, int]) -> tuple[int, np.ndarray]:
+                struct_idx, roi_name, ch = job
+                return ch, self._contours_to_mask(struct_idx, roi_name)
+
+            if self.mask_thread_count > 1 and len(jobs) > 1:
+                with ThreadPoolExecutor(max_workers=self.mask_thread_count) as pool:
+                    results = list(pool.map(_raster, jobs))
+            else:
+                results = [_raster(job) for job in jobs]
+
+            for ch, roi_mask in results:
+                # Union the ROI into its channel, keeping it binary. Operate only
+                # on the (z, rows, cols) channel view -- the previous
+                # ``self.mask[self.mask > 1] = 1`` rescanned the entire 4-D array
+                # once per ROI (O(n_rois) passes over ~all voxels).
+                channel = self.mask[..., ch]
+                np.maximum(channel, roi_mask, out=channel)
 
         # Build per-ROI sitk handles
         for name in self.Contour_Names:
@@ -1355,6 +1405,8 @@ class DicomReaderWriter:
             "require_all_contours": self.require_all_contours,
             "Contour_Names": self.Contour_Names, "description": self.description,
             "get_dose_output": self.get_dose_output,
+            # Spare cores go to per-ROI rasterisation when few series are written.
+            "mask_thread_count": _mask_threads_for(thread_count, len(items)),
         }
 
         pbar = tqdm(total=len(items), desc="Writing per-ROI NIfTI files...")
@@ -1674,6 +1726,9 @@ class DicomReaderWriter:
             "require_all_contours": self.require_all_contours,
             "Contour_Names": wanted_rois, "description": self.description,
             "get_dose_output": self.get_dose_output,
+            # Hand leftover cores to per-ROI rasterisation when few series are
+            # being processed (e.g. a single multi-ROI series).
+            "mask_thread_count": _mask_threads_for(thread_count, len(todo)),
         }
 
         rows: list[dict] = []

--- a/src/DicomRTTool/ReaderWriter.py
+++ b/src/DicomRTTool/ReaderWriter.py
@@ -25,6 +25,7 @@ from __future__ import annotations
 import copy
 import logging
 import os
+import re
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from pathlib import Path
 
@@ -37,6 +38,7 @@ from pydicom.tag import Tag
 from tqdm import tqdm
 
 from ._internal import DEFAULT_WORKERS as _DEFAULT_WORKERS
+from ._internal.anonymizer import DEFAULT_SALT, AnonymizationKey, hash_series
 from ._internal.indexer import (
     DicomFolderLoader,
     add_sops,
@@ -53,13 +55,29 @@ from .Services.DicomBases import (
     SitkDicomKeys,
     dcmread,
 )
-from .Services.StaticScripts import add_to_mask, poly2mask
+from .Services.StaticScripts import add_to_mask, poly2mask, resample_to_spacing
 from .Viewer import plot_scroll_Image  # noqa: F401  (re-export)
 
 logger = logging.getLogger(__name__)
 
 # Re-export for backward compatibility.
 dcmread_function = dcmread
+
+# Filename sanitisation for the per-ROI export layout (Windows-safe).
+_INVALID_FILENAME_CHARS = re.compile(r'[<>:"/\\|?*\x00-\x1f]')
+_RESERVED_FILENAMES = {
+    "CON", "PRN", "AUX", "NUL",
+    *(f"COM{i}" for i in range(1, 10)),
+    *(f"LPT{i}" for i in range(1, 10)),
+}
+
+
+def _sanitize_filename(name: str) -> str:
+    """Return *name* stripped of characters illegal in Windows filenames."""
+    cleaned = _INVALID_FILENAME_CHARS.sub("_", name or "").strip().rstrip(". ")
+    if cleaned.upper() in _RESERVED_FILENAMES:
+        cleaned = f"_{cleaned}"
+    return cleaned
 
 
 # ---------------------------------------------------------------------------
@@ -1082,32 +1100,52 @@ class DicomReaderWriter:
 
     # -- NIfTI I/O ----------------------------------------------------------
 
-    def write_images_annotations(self, out_path: PathLike) -> None:
+    def write_images_annotations(
+        self,
+        out_path: PathLike,
+        output_spacing: tuple[float, float, float] | None = None,
+    ) -> None:
         """Write the current image and mask to NIfTI files.
 
         Args:
             out_path: Directory for output files.
+            output_spacing: Optional ``(x, y, z)`` spacing in mm to resample
+                the outputs to. The image and dose are resampled with linear
+                interpolation; the label mask uses nearest-neighbour so labels
+                are never blended. When ``None`` (default) outputs keep the
+                native DICOM geometry and behaviour is unchanged.
         """
         os.makedirs(out_path, exist_ok=True)
         img_path = os.path.join(out_path, f"Overall_Data_{self.description}_{self.iteration}.nii.gz")
         ann_path = os.path.join(out_path, f"Overall_mask_{self.description}_y{self.iteration}.nii.gz")
 
         handle = self.dicom_handle
+        if output_spacing is not None:
+            handle = resample_to_spacing(handle, output_spacing, "Linear")
         if handle.GetPixelIDTypeAsString().find("32-bit signed integer") != 0:
             handle = sitk.Cast(handle, sitk.sitkFloat32)
         sitk.WriteImage(handle, img_path)
 
         ann = self.annotation_handle
-        ann.SetSpacing(self.dicom_handle.GetSpacing())
-        ann.SetOrigin(self.dicom_handle.GetOrigin())
-        ann.SetDirection(self.dicom_handle.GetDirection())
+        if output_spacing is None:
+            # Keep the legacy behaviour: copy geometry from the image handle.
+            ann.SetSpacing(self.dicom_handle.GetSpacing())
+            ann.SetOrigin(self.dicom_handle.GetOrigin())
+            ann.SetDirection(self.dicom_handle.GetDirection())
+        else:
+            # The resampled mask already carries the new geometry; copying the
+            # native spacing back would corrupt it.
+            ann = resample_to_spacing(ann, output_spacing, "Nearest")
         if ann.GetPixelIDTypeAsString().find("int") == -1:
             ann = sitk.Cast(ann, sitk.sitkUInt8)
         sitk.WriteImage(ann, ann_path)
 
         if self.dose_handle:
             dose_path = os.path.join(out_path, f"Overall_dose_{self.description}_{self.iteration}.nii.gz")
-            sitk.WriteImage(self.dose_handle, dose_path)
+            dose = self.dose_handle
+            if output_spacing is not None:
+                dose = resample_to_spacing(dose, output_spacing, "Linear")
+            sitk.WriteImage(dose, dose_path)
 
         marker = os.path.join(
             self.series_instances_dictionary[self.index].path,
@@ -1248,6 +1286,246 @@ class DicomReaderWriter:
                 col = f"Volume_{roi} [cc]"
                 df.loc[df.Iteration == iteration, col] = tags["Volumes"][ri]
         df.to_csv(index_file, index=False)
+
+    # -- Per-ROI NIfTI writing (C#-compatible layout) ----------------------
+
+    def write_per_roi(
+        self,
+        out_path: PathLike,
+        output_spacing: tuple[float, float, float] | None = None,
+        anonymize: bool = False,
+        salt: str = DEFAULT_SALT,
+        thread_count: int = _DEFAULT_WORKERS,
+        rois: list[str] | None = None,
+        manifest_name: str = "manifest.csv",
+        key_file_name: str = "anonymization_key.json",
+        dose_type: str = "PLAN",
+    ) -> None:
+        """Export every series-with-contours to a per-ROI NIfTI layout.
+
+        For each series an ``<case_id>/`` folder is written containing:
+
+        * ``image.nii.gz`` — the image volume;
+        * ``masks/<roi>.nii.gz`` — one binary mask per ROI;
+        * ``doses/<desc>.nii.gz`` — the summed dose grid, only when the series
+          carries dose *and* this reader was built with ``get_dose_output=True``.
+
+        A single ``manifest.csv`` (no persistent iteration index) is written at
+        *out_path* with one row per series: identifiers (raw and/or hashed),
+        the output spacing, and per-ROI volume in cc (``-1`` when an ROI is
+        absent for that series).
+
+        When ``output_spacing`` is given the image and dose are resampled with
+        linear interpolation and masks with nearest-neighbour. When
+        ``anonymize`` is ``True`` the case folder is named by the series hash,
+        only hashed identifiers are written to the manifest, and an
+        ``anonymization_key.json`` reverse-lookup file is saved at *out_path*.
+
+        Args:
+            out_path: Output directory.
+            output_spacing: Optional ``(x, y, z)`` mm spacing to resample to.
+            anonymize: Hash identifiers + folder names and write a key file.
+            salt: Salt for the deterministic hashes.
+            thread_count: Number of parallel worker threads.
+            rois: ROI names to export. Defaults to :attr:`Contour_Names`.
+            manifest_name: Filename of the manifest CSV.
+            key_file_name: Filename of the anonymization key JSON.
+            dose_type: ``DoseSummationType`` filter used when loading dose.
+        """
+        os.makedirs(out_path, exist_ok=True)
+        wanted_rois = [r.lower() for r in (rois if rois is not None else self.Contour_Names)]
+        if not wanted_rois:
+            logger.warning("No ROIs to export. Set Contour_Names or pass rois=...")
+            return
+
+        items = list(self.indexes_with_contours)
+        if not items:
+            logger.warning("No indexes with contours found; nothing to export.")
+            return
+
+        key_dict = {
+            "series_instances_dictionary": self.series_instances_dictionary,
+            "associations": self.associations, "arg_max": self.arg_max,
+            "require_all_contours": self.require_all_contours,
+            "Contour_Names": self.Contour_Names, "description": self.description,
+            "get_dose_output": self.get_dose_output,
+        }
+
+        pbar = tqdm(total=len(items), desc="Writing per-ROI NIfTI files...")
+
+        def _worker(index: int) -> dict | None:
+            base = DicomReaderWriter(**key_dict)
+            base.verbose = False
+            try:
+                base.set_index(index)
+                base.get_images_and_mask()
+                return self._export_one_series(
+                    base, index, out_path, wanted_rois,
+                    output_spacing, anonymize, salt, dose_type,
+                )
+            except Exception:
+                entry = base.series_instances_dictionary.get(index)
+                logger.warning("Failed on %s", getattr(entry, "path", index), exc_info=True)
+                return None
+
+        rows: list[dict] = []
+        if thread_count <= 1:
+            for index in items:
+                result = _worker(index)
+                if result is not None:
+                    rows.append(result)
+                pbar.update()
+        else:
+            with ThreadPoolExecutor(max_workers=thread_count) as pool:
+                futures = {pool.submit(_worker, index): index for index in items}
+                for future in as_completed(futures):
+                    result = future.result()
+                    if result is not None:
+                        rows.append(result)
+                    pbar.update()
+        pbar.close()
+
+        if not rows:
+            logger.warning("No series exported; manifest not written.")
+            return
+
+        self._write_manifest(rows, wanted_rois, out_path, manifest_name, anonymize)
+
+        if anonymize:
+            key = AnonymizationKey(salt=salt)
+            for row in rows:
+                key.patients.setdefault(row["patient_hash"], row["_mrn"])
+                key.studies.setdefault(row["study_hash"], row["_study_uid"])
+                key.series.setdefault(row["series_hash"], row["_series_uid"])
+            key.save(os.path.join(out_path, key_file_name))
+
+    def _export_one_series(
+        self,
+        base: DicomReaderWriter,
+        index: int,
+        out_path: PathLike,
+        wanted_rois: list[str],
+        output_spacing: tuple[float, float, float] | None,
+        anonymize: bool,
+        salt: str,
+        dose_type: str,
+    ) -> dict:
+        """Write one series' image/masks/dose tree and return its manifest data."""
+        from ._internal.anonymizer import hash_patient, hash_study  # local: keep import surface small
+
+        entry = base.series_instances_dictionary[index]
+        mrn = entry.PatientID or ""
+        study_uid = entry.StudyInstanceUID or ""
+        series_uid = entry.SeriesInstanceUID or ""
+
+        patient_hash = hash_patient(mrn, salt)
+        study_hash = hash_study(study_uid, salt)
+        series_hash = hash_series(series_uid, salt)
+
+        case_id = (
+            series_hash if anonymize
+            else _sanitize_filename(f"{mrn}_{series_uid[-8:]}") or series_hash
+        )
+
+        case_dir = os.path.join(out_path, case_id)
+        masks_dir = os.path.join(case_dir, "masks")
+        os.makedirs(masks_dir, exist_ok=True)
+
+        # ROIs genuinely present in this series' RT structure(s). ``get_mask``
+        # allocates an all-zero mask for *every* ``Contour_Name``, so the mask
+        # dictionary alone cannot distinguish "absent" from "empty"; resolve
+        # the RT membership instead so absent ROIs become -1 in the manifest
+        # and no empty mask file is written.
+        present_rois: set[str] = set()
+        for rt in entry.RTs.values():
+            for raw_name in rt.ROIs_In_Structure:
+                canonical = base._resolve_roi_name(raw_name)
+                if canonical:
+                    present_rois.add(canonical)
+
+        # --- image (linear) ---
+        image_handle = base.dicom_handle
+        if output_spacing is not None:
+            image_handle = resample_to_spacing(image_handle, output_spacing, "Linear")
+        if image_handle.GetPixelIDTypeAsString().find("32-bit signed integer") != 0:
+            image_handle = sitk.Cast(image_handle, sitk.sitkFloat32)
+        sitk.WriteImage(image_handle, os.path.join(case_dir, "image.nii.gz"))
+
+        # --- masks (nearest neighbour) ---
+        native_spacing = base.dicom_handle.GetSpacing()
+        out_spacing = tuple(float(s) for s in (output_spacing if output_spacing is not None else native_spacing))
+        voxel_cc = float(np.prod(out_spacing)) / 1000.0
+        roi_volumes: dict[str, float] = {}
+        for roi in wanted_rois:
+            if roi not in present_rois or roi not in base.mask_dictionary:
+                continue
+            mask_img = base.mask_dictionary[roi]
+            if output_spacing is not None:
+                mask_img = resample_to_spacing(mask_img, output_spacing, "Nearest")
+            mask_img = sitk.Cast(mask_img, sitk.sitkUInt8)
+            sitk.WriteImage(mask_img, os.path.join(masks_dir, f"{_sanitize_filename(roi)}.nii.gz"))
+            n_vox = int(np.sum(sitk.GetArrayViewFromImage(mask_img)))
+            roi_volumes[roi] = round(n_vox * voxel_cc, 3)
+
+        # --- dose (linear), only when present ---
+        if base.dose_handle is not None:
+            doses_dir = os.path.join(case_dir, "doses")
+            os.makedirs(doses_dir, exist_ok=True)
+            dose_img = base.dose_handle
+            if output_spacing is not None:
+                dose_img = resample_to_spacing(dose_img, output_spacing, "Linear")
+            desc = None
+            for rd in entry.RDs.values():
+                if rd.Description:
+                    desc = rd.Description
+                    break
+            desc = _sanitize_filename(desc or dose_type or "dose") or "dose"
+            sitk.WriteImage(dose_img, os.path.join(doses_dir, f"{desc}.nii.gz"))
+
+        return {
+            "case_id": case_id,
+            "patient_hash": patient_hash,
+            "study_hash": study_hash,
+            "series_hash": series_hash,
+            "_mrn": mrn,
+            "_study_uid": study_uid,
+            "_series_uid": series_uid,
+            "spacing_x": out_spacing[0],
+            "spacing_y": out_spacing[1],
+            "spacing_z": out_spacing[2],
+            "volumes": roi_volumes,
+        }
+
+    def _write_manifest(
+        self,
+        rows: list[dict],
+        wanted_rois: list[str],
+        out_path: PathLike,
+        manifest_name: str,
+        anonymize: bool,
+    ) -> None:
+        """Write the single per-series manifest CSV (one row per series)."""
+        records = []
+        for row in rows:
+            record: dict = {
+                "case_id": row["case_id"],
+                "patient_hash": row["patient_hash"],
+                "study_hash": row["study_hash"],
+                "series_hash": row["series_hash"],
+            }
+            if not anonymize:
+                record["PatientID"] = row["_mrn"]
+                record["StudyInstanceUID"] = row["_study_uid"]
+                record["SeriesInstanceUID"] = row["_series_uid"]
+            record["spacing_x"] = row["spacing_x"]
+            record["spacing_y"] = row["spacing_y"]
+            record["spacing_z"] = row["spacing_z"]
+            for roi in wanted_rois:
+                record[f"{roi} cc"] = row["volumes"].get(roi, -1)
+            records.append(record)
+
+        df = pd.DataFrame(records)
+        df.to_csv(os.path.join(out_path, manifest_name), index=False)
 
     # -- CSV characterisation ---------------------------------------------
 

--- a/src/DicomRTTool/ReaderWriter.py
+++ b/src/DicomRTTool/ReaderWriter.py
@@ -38,7 +38,13 @@ from pydicom.tag import Tag
 from tqdm import tqdm
 
 from ._internal import DEFAULT_WORKERS as _DEFAULT_WORKERS
-from ._internal.anonymizer import DEFAULT_SALT, AnonymizationKey, hash_series
+from ._internal.anonymizer import (
+    DEFAULT_SALT,
+    AnonymizationKey,
+    hash_patient,
+    hash_series,
+    hash_study,
+)
 from ._internal.indexer import (
     DicomFolderLoader,
     add_sops,
@@ -1411,8 +1417,6 @@ class DicomReaderWriter:
         dose_type: str,
     ) -> dict:
         """Write one series' image/masks/dose tree and return its manifest data."""
-        from ._internal.anonymizer import hash_patient, hash_study  # local: keep import surface small
-
         entry = base.series_instances_dictionary[index]
         mrn = entry.PatientID or ""
         study_uid = entry.StudyInstanceUID or ""
@@ -1496,6 +1500,36 @@ class DicomReaderWriter:
             "volumes": roi_volumes,
         }
 
+    def _manifest_record(
+        self,
+        row: dict,
+        wanted_rois: list[str],
+        anonymize: bool,
+        include_case_id: bool = True,
+    ) -> dict:
+        """Flatten one collected series ``row`` into a manifest CSV record.
+
+        Columns: optional ``case_id``, the three hashes, the raw identifiers
+        (omitted when *anonymize*), the output spacing, and one ``<roi> cc``
+        column per wanted ROI (``-1`` when the ROI is absent for that series).
+        """
+        record: dict = {}
+        if include_case_id and "case_id" in row:
+            record["case_id"] = row["case_id"]
+        record["patient_hash"] = row["patient_hash"]
+        record["study_hash"] = row["study_hash"]
+        record["series_hash"] = row["series_hash"]
+        if not anonymize:
+            record["PatientID"] = row["_mrn"]
+            record["StudyInstanceUID"] = row["_study_uid"]
+            record["SeriesInstanceUID"] = row["_series_uid"]
+        record["spacing_x"] = row["spacing_x"]
+        record["spacing_y"] = row["spacing_y"]
+        record["spacing_z"] = row["spacing_z"]
+        for roi in wanted_rois:
+            record[f"{roi} cc"] = row["volumes"].get(roi, -1)
+        return record
+
     def _write_manifest(
         self,
         rows: list[dict],
@@ -1505,27 +1539,175 @@ class DicomReaderWriter:
         anonymize: bool,
     ) -> None:
         """Write the single per-series manifest CSV (one row per series)."""
-        records = []
-        for row in rows:
-            record: dict = {
-                "case_id": row["case_id"],
-                "patient_hash": row["patient_hash"],
-                "study_hash": row["study_hash"],
-                "series_hash": row["series_hash"],
-            }
-            if not anonymize:
-                record["PatientID"] = row["_mrn"]
-                record["StudyInstanceUID"] = row["_study_uid"]
-                record["SeriesInstanceUID"] = row["_series_uid"]
-            record["spacing_x"] = row["spacing_x"]
-            record["spacing_y"] = row["spacing_y"]
-            record["spacing_z"] = row["spacing_z"]
-            for roi in wanted_rois:
-                record[f"{roi} cc"] = row["volumes"].get(roi, -1)
-            records.append(record)
-
+        records = [self._manifest_record(row, wanted_rois, anonymize) for row in rows]
         df = pd.DataFrame(records)
         df.to_csv(os.path.join(out_path, manifest_name), index=False)
+
+    def _collect_series_row(
+        self,
+        base: DicomReaderWriter,
+        index: int,
+        wanted_rois: list[str],
+        salt: str,
+    ) -> dict:
+        """Compute identifiers, native image spacing, and per-ROI cc volumes.
+
+        Does not write any NIfTI files -- used by :meth:`create_manifest`.
+        Volumes are taken from the native-resolution masks; an ROI absent from
+        the series' RT structure(s) is simply omitted (becomes ``-1`` at CSV
+        write time).
+        """
+        entry = base.series_instances_dictionary[index]
+        mrn = entry.PatientID or ""
+        study_uid = entry.StudyInstanceUID or ""
+        series_uid = entry.SeriesInstanceUID or ""
+
+        spacing = tuple(float(s) for s in base.dicom_handle.GetSpacing())
+        voxel_cc = float(np.prod(spacing)) / 1000.0
+
+        present_rois: set[str] = set()
+        for rt in entry.RTs.values():
+            for raw_name in rt.ROIs_In_Structure:
+                canonical = base._resolve_roi_name(raw_name)
+                if canonical:
+                    present_rois.add(canonical)
+
+        volumes: dict[str, float] = {}
+        for roi in wanted_rois:
+            if roi in present_rois and roi in base.mask_dictionary:
+                n_vox = int(np.sum(sitk.GetArrayViewFromImage(base.mask_dictionary[roi])))
+                volumes[roi] = round(n_vox * voxel_cc, 3)
+
+        return {
+            "patient_hash": hash_patient(mrn, salt),
+            "study_hash": hash_study(study_uid, salt),
+            "series_hash": hash_series(series_uid, salt),
+            "_mrn": mrn,
+            "_study_uid": study_uid,
+            "_series_uid": series_uid,
+            "spacing_x": spacing[0],
+            "spacing_y": spacing[1],
+            "spacing_z": spacing[2],
+            "volumes": volumes,
+        }
+
+    def create_manifest(
+        self,
+        output_path: PathLike,
+        anonymize: bool = False,
+        salt: str = DEFAULT_SALT,
+        rois: list[str] | None = None,
+        thread_count: int = _DEFAULT_WORKERS,
+    ) -> None:
+        """Build, or incrementally extend, a metadata manifest CSV.
+
+        Writes one row per series-with-contours to *output_path*, mirroring the
+        C# tool's ``export_manifest.csv``: identifiers (raw and/or hashed),
+        the image spacing (``spacing_x/y/z``), and the mask volume in cc for
+        every ROI name (one ``<roi> cc`` column each; ``-1`` when an ROI is
+        absent from that series). Unlike :meth:`write_per_roi`, no NIfTI files
+        are written -- this produces the manifest only.
+
+        If *output_path* already exists it is read and **extended in place**:
+        rows for series already recorded (matched by ``SeriesInstanceUID`` or
+        ``series_hash``) are left untouched, only new series are appended, and
+        any new ROI columns are added (filled with ``-1`` for pre-existing
+        rows). This makes it safe to call repeatedly as more data is walked.
+
+        Args:
+            output_path: CSV path to create or extend.
+            anonymize: Write only the hashed identifiers (no raw IDs).
+            salt: Salt for the deterministic identifier hashes.
+            rois: ROI names to record. Defaults to :attr:`Contour_Names`.
+            thread_count: Number of parallel worker threads.
+        """
+        wanted_rois = [r.lower() for r in (rois if rois is not None else self.Contour_Names)]
+        if not wanted_rois:
+            logger.warning("No ROIs to record. Set Contour_Names or pass rois=...")
+            return
+        if not self.indexes_with_contours:
+            logger.warning("No indexes with contours found; manifest not written.")
+            return
+
+        # Load any existing manifest so we only append genuinely new series.
+        existing_df = None
+        existing_keys: set[str] = set()
+        if os.path.exists(output_path):
+            existing_df = pd.read_csv(output_path)
+            for col in ("SeriesInstanceUID", "series_hash"):
+                if col in existing_df.columns:
+                    existing_keys.update(existing_df[col].dropna().astype(str).tolist())
+
+        # Skip series already present (cheap -- no image load needed).
+        todo: list[int] = []
+        for index in self.indexes_with_contours:
+            entry = self.series_instances_dictionary[index]
+            series_uid = entry.SeriesInstanceUID or ""
+            if series_uid in existing_keys or hash_series(series_uid, salt) in existing_keys:
+                continue
+            todo.append(index)
+
+        key_dict = {
+            "series_instances_dictionary": self.series_instances_dictionary,
+            "associations": self.associations, "arg_max": self.arg_max,
+            "require_all_contours": self.require_all_contours,
+            "Contour_Names": self.Contour_Names, "description": self.description,
+            "get_dose_output": self.get_dose_output,
+        }
+
+        rows: list[dict] = []
+        if todo:
+            pbar = tqdm(total=len(todo), desc="Building manifest...")
+
+            def _worker(index: int) -> dict | None:
+                base = DicomReaderWriter(**key_dict)
+                base.verbose = False
+                try:
+                    base.set_index(index)
+                    base.get_images_and_mask()
+                    return self._collect_series_row(base, index, wanted_rois, salt)
+                except Exception:
+                    entry = base.series_instances_dictionary.get(index)
+                    logger.warning("Failed on %s", getattr(entry, "path", index), exc_info=True)
+                    return None
+
+            if thread_count <= 1:
+                for index in todo:
+                    result = _worker(index)
+                    if result is not None:
+                        rows.append(result)
+                    pbar.update()
+            else:
+                with ThreadPoolExecutor(max_workers=thread_count) as pool:
+                    futures = {pool.submit(_worker, index): index for index in todo}
+                    for future in as_completed(futures):
+                        result = future.result()
+                        if result is not None:
+                            rows.append(result)
+                        pbar.update()
+            pbar.close()
+
+        new_df = pd.DataFrame(
+            [self._manifest_record(row, wanted_rois, anonymize, include_case_id=False) for row in rows]
+        )
+
+        if existing_df is not None and not existing_df.empty:
+            combined = pd.concat([existing_df, new_df], ignore_index=True) if not new_df.empty else existing_df
+        else:
+            combined = new_df
+
+        if combined is None or combined.empty:
+            logger.warning("No manifest rows to write.")
+            return
+
+        # Absent ROI volume cells (new columns on old rows, or vice versa) -> -1.
+        for col in [c for c in combined.columns if str(c).endswith(" cc")]:
+            combined[col] = combined[col].fillna(-1)
+
+        out_dir = os.path.dirname(os.path.abspath(output_path))
+        if out_dir:
+            os.makedirs(out_dir, exist_ok=True)
+        combined.to_csv(output_path, index=False)
 
     # -- CSV characterisation ---------------------------------------------
 

--- a/src/DicomRTTool/ReaderWriter.py
+++ b/src/DicomRTTool/ReaderWriter.py
@@ -61,7 +61,12 @@ from .Services.DicomBases import (
     SitkDicomKeys,
     dcmread,
 )
-from .Services.StaticScripts import add_to_mask, poly2mask, resample_to_spacing
+from .Services.StaticScripts import (
+    add_to_mask,
+    poly2mask,
+    resample_to_reference,
+    resample_to_spacing,
+)
 from .Viewer import plot_scroll_Image  # noqa: F401  (re-export)
 
 logger = logging.getLogger(__name__)
@@ -1178,6 +1183,8 @@ class DicomReaderWriter:
         handle = self.dicom_handle
         if output_spacing is not None:
             handle = resample_to_spacing(handle, output_spacing, "Linear")
+        # Grid the dose is resampled onto so image/mask/dose share geometry.
+        resampled_image_grid = handle
         if handle.GetPixelIDTypeAsString().find("32-bit signed integer") != 0:
             handle = sitk.Cast(handle, sitk.sitkFloat32)
         sitk.WriteImage(handle, img_path)
@@ -1200,7 +1207,9 @@ class DicomReaderWriter:
             dose_path = os.path.join(out_path, f"Overall_dose_{self.description}_{self.iteration}.nii.gz")
             dose = self.dose_handle
             if output_spacing is not None:
-                dose = resample_to_spacing(dose, output_spacing, "Linear")
+                # Onto the resampled image grid, so the dose matches the image
+                # and mask size & geometry exactly.
+                dose = resample_to_reference(dose, resampled_image_grid, "Linear")
             sitk.WriteImage(dose, dose_path)
 
         marker = os.path.join(
@@ -1503,6 +1512,9 @@ class DicomReaderWriter:
         image_handle = base.dicom_handle
         if output_spacing is not None:
             image_handle = resample_to_spacing(image_handle, output_spacing, "Linear")
+        # The resampled image defines the grid the dose is resampled onto, so
+        # image, masks, and dose all share one size & geometry.
+        resampled_image_grid = image_handle
         if image_handle.GetPixelIDTypeAsString().find("32-bit signed integer") != 0:
             image_handle = sitk.Cast(image_handle, sitk.sitkFloat32)
         sitk.WriteImage(image_handle, os.path.join(case_dir, "image.nii.gz"))
@@ -1529,7 +1541,9 @@ class DicomReaderWriter:
             os.makedirs(doses_dir, exist_ok=True)
             dose_img = base.dose_handle
             if output_spacing is not None:
-                dose_img = resample_to_spacing(dose_img, output_spacing, "Linear")
+                # Resample onto the resampled *image* grid (not the dose's own
+                # grid) so dose, image, and masks share size & geometry.
+                dose_img = resample_to_reference(dose_img, resampled_image_grid, "Linear")
             desc = None
             for rd in entry.RDs.values():
                 if rd.Description:

--- a/src/DicomRTTool/Services/StaticScripts.py
+++ b/src/DicomRTTool/Services/StaticScripts.py
@@ -119,3 +119,33 @@ def resample_to_spacing(
     resampler.SetInterpolator(_INTERPOLATORS[interpolator])
     resampler.SetDefaultPixelValue(0)
     return resampler.Execute(handle)
+
+
+def resample_to_reference(
+    handle: sitk.Image,
+    reference: sitk.Image,
+    interpolator: str = "Linear",
+) -> sitk.Image:
+    """Resample *handle* onto *reference*'s exact grid.
+
+    The output takes the reference's size, spacing, origin, and direction, so
+    the result is voxel-aligned with *reference*. Used to put the dose on the
+    resampled image's grid so image, masks, and dose share one geometry.
+
+    Args:
+        handle: Image to resample.
+        reference: Image whose grid the output should match.
+        interpolator: ``"Linear"`` (images / dose) or ``"Nearest"`` (masks).
+
+    Returns:
+        A resampled :class:`SimpleITK.Image` on *reference*'s grid.
+    """
+    if interpolator not in _INTERPOLATORS:
+        raise ValueError(
+            f"Unknown interpolator '{interpolator}'. "
+            f"Expected one of {sorted(_INTERPOLATORS)}."
+        )
+    return sitk.Resample(
+        handle, reference, sitk.Transform(),
+        _INTERPOLATORS[interpolator], 0.0, handle.GetPixelID(),
+    )

--- a/src/DicomRTTool/Services/StaticScripts.py
+++ b/src/DicomRTTool/Services/StaticScripts.py
@@ -107,7 +107,7 @@ def resample_to_spacing(
     in_size = handle.GetSize()
     in_spacing = handle.GetSpacing()
     new_size = [
-        max(1, int(math.ceil(in_size[i] * in_spacing[i] / output_spacing[i])))
+        max(1, math.ceil(in_size[i] * in_spacing[i] / output_spacing[i]))
         for i in range(3)
     ]
 

--- a/src/DicomRTTool/Services/StaticScripts.py
+++ b/src/DicomRTTool/Services/StaticScripts.py
@@ -2,6 +2,7 @@
 
 Provides functions to convert RT Structure contour polygons into binary
 mask arrays and to interpolate non-planar contour segments onto a voxel grid.
+Also provides a spacing-tuple resampler used by the NIfTI export helpers.
 """
 from __future__ import annotations
 
@@ -9,6 +10,7 @@ import math
 
 import cv2
 import numpy as np
+import SimpleITK as sitk
 
 
 def poly2mask(
@@ -60,3 +62,60 @@ def add_to_mask(
         for r in (r_lo, r_hi):
             for c in (c_lo, c_hi):
                 mask[z, r, c] = mask_value
+
+
+# Interpolator string -> SimpleITK enum. ``"Linear"`` for images and dose,
+# ``"Nearest"`` for label masks (so labels are never blended).
+_INTERPOLATORS = {
+    "Linear": sitk.sitkLinear,
+    "Nearest": sitk.sitkNearestNeighbor,
+    "NearestNeighbor": sitk.sitkNearestNeighbor,
+    "BSpline": sitk.sitkBSpline,
+}
+
+
+def resample_to_spacing(
+    handle: sitk.Image,
+    output_spacing: tuple[float, float, float],
+    interpolator: str = "Linear",
+) -> sitk.Image:
+    """Resample a SimpleITK image to a target voxel spacing.
+
+    The output covers the same physical extent as the input: the new size
+    along each axis is ``ceil(in_size * in_spacing / out_spacing)`` (clamped
+    to a minimum of 1), while the origin and direction cosines are preserved.
+    This mirrors the C# ``ResampleToSpacing`` used by the reference tool.
+
+    Args:
+        handle: Input image.
+        output_spacing: Desired ``(x, y, z)`` spacing in mm.
+        interpolator: ``"Linear"`` (images / dose) or ``"Nearest"`` (masks).
+            Also accepts ``"NearestNeighbor"`` / ``"BSpline"``.
+
+    Returns:
+        A resampled :class:`SimpleITK.Image`.
+    """
+    if interpolator not in _INTERPOLATORS:
+        raise ValueError(
+            f"Unknown interpolator '{interpolator}'. "
+            f"Expected one of {sorted(_INTERPOLATORS)}."
+        )
+    output_spacing = tuple(float(s) for s in output_spacing)
+    if len(output_spacing) != 3 or any(s <= 0 for s in output_spacing):
+        raise ValueError(f"output_spacing must be three positive numbers; got {output_spacing}")
+
+    in_size = handle.GetSize()
+    in_spacing = handle.GetSpacing()
+    new_size = [
+        max(1, int(math.ceil(in_size[i] * in_spacing[i] / output_spacing[i])))
+        for i in range(3)
+    ]
+
+    resampler = sitk.ResampleImageFilter()
+    resampler.SetOutputSpacing(output_spacing)
+    resampler.SetSize(new_size)
+    resampler.SetOutputOrigin(handle.GetOrigin())
+    resampler.SetOutputDirection(handle.GetDirection())
+    resampler.SetInterpolator(_INTERPOLATORS[interpolator])
+    resampler.SetDefaultPixelValue(0)
+    return resampler.Execute(handle)

--- a/src/DicomRTTool/__init__.py
+++ b/src/DicomRTTool/__init__.py
@@ -22,7 +22,7 @@ from ._internal.anonymizer import (
     hash_study,
 )
 from .ReaderWriter import DicomReaderWriter, ROIAssociationClass
-from .Services.StaticScripts import resample_to_spacing
+from .Services.StaticScripts import resample_to_reference, resample_to_spacing
 from .Viewer import plot_scroll_Image
 
 __all__ = [
@@ -34,6 +34,7 @@ __all__ = [
     "hash_series",
     "hash_study",
     "plot_scroll_Image",
+    "resample_to_reference",
     "resample_to_spacing",
     "sitk",
 ]

--- a/src/DicomRTTool/__init__.py
+++ b/src/DicomRTTool/__init__.py
@@ -14,12 +14,26 @@ from __future__ import annotations
 
 import SimpleITK as sitk
 
+from ._internal.anonymizer import (
+    AnonymizationKey,
+    deterministic_hash_string,
+    hash_patient,
+    hash_series,
+    hash_study,
+)
 from .ReaderWriter import DicomReaderWriter, ROIAssociationClass
+from .Services.StaticScripts import resample_to_spacing
 from .Viewer import plot_scroll_Image
 
 __all__ = [
+    "AnonymizationKey",
     "DicomReaderWriter",
     "ROIAssociationClass",
+    "deterministic_hash_string",
+    "hash_patient",
+    "hash_series",
+    "hash_study",
     "plot_scroll_Image",
+    "resample_to_spacing",
     "sitk",
 ]

--- a/src/DicomRTTool/_internal/anonymizer.py
+++ b/src/DicomRTTool/_internal/anonymizer.py
@@ -1,0 +1,121 @@
+"""Deterministic identifier hashing for anonymized NIfTI exports.
+
+Replicates the C# ``AnonymizationService`` byte-for-byte so the two tools
+produce identical hashes for the same identifiers and salt:
+
+* a hash is ``prefix + first N bytes of SHA256(f"{input}:{salt}") as hex``;
+* patient: input ``"PATIENT:" + MRN``, prefix ``"P"``, 5 bytes (10 hex chars);
+* study:   input ``"STUDY:" + StudyInstanceUID``, prefix ``"ST"``, 6 bytes;
+* series:  input ``"SERIES:" + SeriesInstanceUID``, prefix ``"SE"``, 6 bytes.
+
+The three reverse-lookup maps (hash -> original identifier) are persisted to a
+JSON key file so an anonymized export can be de-anonymized later and so
+re-running an export reuses the same hashes.
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+
+from ..Services.DicomBases import PathLike
+
+DEFAULT_SALT = "DicomToNifti"
+
+
+def deterministic_hash_string(input_string: str, salt: str, prefix: str = "A", num_bytes: int = 6) -> str:
+    """Return ``prefix`` + the first ``num_bytes`` of ``SHA256(input:salt)`` as hex.
+
+    Slicing happens on the raw digest bytes *before* hex-encoding (so
+    ``num_bytes=6`` yields 12 hex characters), matching the C# implementation.
+    """
+    salted = f"{input_string}:{salt}"
+    digest = hashlib.sha256(salted.encode("utf-8")).digest()
+    return prefix + digest[:num_bytes].hex()
+
+
+def hash_patient(mrn: str | None, salt: str = DEFAULT_SALT) -> str:
+    """Hash a patient MRN (input ``"PATIENT:<mrn>"``, prefix ``"P"``, 5 bytes)."""
+    return deterministic_hash_string(f"PATIENT:{mrn or ''}", salt, "P", 5)
+
+
+def hash_study(study_uid: str | None, salt: str = DEFAULT_SALT) -> str:
+    """Hash a StudyInstanceUID (input ``"STUDY:<uid>"``, prefix ``"ST"``, 6 bytes)."""
+    return deterministic_hash_string(f"STUDY:{study_uid or ''}", salt, "ST", 6)
+
+
+def hash_series(series_uid: str | None, salt: str = DEFAULT_SALT) -> str:
+    """Hash a SeriesInstanceUID (input ``"SERIES:<uid>"``, prefix ``"SE"``, 6 bytes)."""
+    return deterministic_hash_string(f"SERIES:{series_uid or ''}", salt, "SE", 6)
+
+
+class AnonymizationKey:
+    """Reverse-lookup maps (hash -> original identifier) plus the salt.
+
+    Mirrors the C# ``AnonymizationKeyFile`` JSON schema so key files are
+    interchangeable between the two tools::
+
+        {"Salt": "...", "Patients": {...}, "Studies": {...}, "Series": {...}}
+    """
+
+    def __init__(self, salt: str = DEFAULT_SALT) -> None:
+        self.salt = salt or DEFAULT_SALT
+        self.patients: dict[str, str] = {}  # patient hash -> MRN
+        self.studies: dict[str, str] = {}   # study hash   -> StudyInstanceUID
+        self.series: dict[str, str] = {}    # series hash  -> SeriesInstanceUID
+
+    # -- persistence --------------------------------------------------------
+
+    @classmethod
+    def load(cls, path: PathLike) -> AnonymizationKey:
+        """Load a key file, or return a fresh instance when it does not exist."""
+        if path and os.path.exists(path):
+            with open(path, encoding="utf-8") as handle:
+                data = json.load(handle)
+            obj = cls(salt=data.get("Salt", DEFAULT_SALT))
+            obj.patients = dict(data.get("Patients", {}))
+            obj.studies = dict(data.get("Studies", {}))
+            obj.series = dict(data.get("Series", {}))
+            return obj
+        return cls()
+
+    def save(self, path: PathLike) -> None:
+        """Write the key file as indented JSON (creating parent dirs)."""
+        directory = os.path.dirname(os.fspath(path))
+        if directory:
+            os.makedirs(directory, exist_ok=True)
+        payload = {
+            "Salt": self.salt,
+            "Patients": self.patients,
+            "Studies": self.studies,
+            "Series": self.series,
+        }
+        with open(path, "w", encoding="utf-8") as handle:
+            json.dump(payload, handle, indent=2)
+
+    # -- registration -------------------------------------------------------
+
+    def register(
+        self,
+        mrn: str | None,
+        study_uid: str | None,
+        series_uid: str | None,
+    ) -> tuple[str, str, str]:
+        """Hash the three identifiers, record the reverse maps, return the hashes."""
+        patient_hash = hash_patient(mrn, self.salt)
+        study_hash = hash_study(study_uid, self.salt)
+        series_hash = hash_series(series_uid, self.salt)
+        self.patients.setdefault(patient_hash, mrn or "")
+        self.studies.setdefault(study_hash, study_uid or "")
+        self.series.setdefault(series_hash, series_uid or "")
+        return patient_hash, study_hash, series_hash
+
+    def merge(self, other: AnonymizationKey) -> None:
+        """Fold another key's reverse maps into this one (in place)."""
+        for mine, theirs in (
+            (self.patients, other.patients),
+            (self.studies, other.studies),
+            (self.series, other.series),
+        ):
+            for key, value in theirs.items():
+                mine.setdefault(key, value)

--- a/tests/test_anonymizer.py
+++ b/tests/test_anonymizer.py
@@ -1,0 +1,107 @@
+"""Tests for the deterministic anonymization hashing + key file.
+
+The hashing must match the C# ``AnonymizationService`` byte-for-byte:
+``prefix + first N bytes of SHA256(f"{input}:{salt}") as lowercase hex``.
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+
+from DicomRTTool import (
+    AnonymizationKey,
+    deterministic_hash_string,
+    hash_patient,
+    hash_series,
+    hash_study,
+)
+from DicomRTTool._internal.anonymizer import DEFAULT_SALT
+
+
+def _expected(input_str: str, salt: str, prefix: str, num_bytes: int) -> str:
+    """Independent re-implementation of the C# formula for cross-checking."""
+    digest = hashlib.sha256(f"{input_str}:{salt}".encode()).digest()
+    return prefix + digest[:num_bytes].hex()
+
+
+class TestDeterministicHash:
+    def test_matches_independent_formula(self):
+        assert deterministic_hash_string("PATIENT:12345", DEFAULT_SALT, "P", 5) == _expected(
+            "PATIENT:12345", DEFAULT_SALT, "P", 5
+        )
+
+    def test_slices_raw_bytes_not_hexdigest(self):
+        # 6 bytes -> 12 hex chars; this fails if the impl used hexdigest()[:6].
+        h = deterministic_hash_string("STUDY:abc", DEFAULT_SALT, "ST", 6)
+        assert len(h) == len("ST") + 12
+
+    def test_patient_study_series_lengths_and_prefixes(self):
+        p = hash_patient("12345")
+        st = hash_study("1.2.3")
+        se = hash_series("1.2.3.4")
+        assert p.startswith("P") and len(p) == 1 + 10   # 5 bytes
+        assert st.startswith("ST") and len(st) == 2 + 12  # 6 bytes
+        assert se.startswith("SE") and len(se) == 2 + 12  # 6 bytes
+
+    def test_regression_anchor_vectors(self):
+        # Frozen vectors: guard against accidental algorithm drift.
+        assert hash_patient("12345") == "P5e91ac4196"
+        assert hash_study("1.2.3") == "ST9b7493c25553"
+        assert hash_series("1.2.3.4") == "SE5f79c3efc041"
+
+    def test_salt_changes_hash(self):
+        assert hash_patient("12345", salt="A") != hash_patient("12345", salt="B")
+
+    def test_namespacing_prevents_collisions(self):
+        # Same raw value, different identifier type -> different hash.
+        assert hash_patient("X", salt="s") != hash_study("X", salt="s")
+
+    def test_none_identifier_is_stable(self):
+        assert hash_patient(None) == hash_patient("")
+
+
+class TestAnonymizationKey:
+    def test_register_returns_hashes_and_records_reverse_maps(self):
+        key = AnonymizationKey()
+        p, st, se = key.register("MRN1", "study-uid", "series-uid")
+        assert key.patients[p] == "MRN1"
+        assert key.studies[st] == "study-uid"
+        assert key.series[se] == "series-uid"
+
+    def test_register_is_idempotent(self):
+        key = AnonymizationKey()
+        first = key.register("MRN1", "s", "se")
+        second = key.register("MRN1", "s", "se")
+        assert first == second
+        assert len(key.patients) == 1
+
+    def test_save_and_load_round_trip(self, tmp_path: Path):
+        key = AnonymizationKey(salt="my-salt")
+        key.register("MRN1", "study-uid", "series-uid")
+        path = tmp_path / "anon.json"
+        key.save(path)
+
+        # Schema matches the C# AnonymizationKeyFile.
+        data = json.loads(path.read_text())
+        assert set(data) == {"Salt", "Patients", "Studies", "Series"}
+        assert data["Salt"] == "my-salt"
+
+        reloaded = AnonymizationKey.load(path)
+        assert reloaded.salt == "my-salt"
+        assert reloaded.patients == key.patients
+        assert reloaded.studies == key.studies
+        assert reloaded.series == key.series
+
+    def test_load_missing_returns_fresh(self, tmp_path: Path):
+        key = AnonymizationKey.load(tmp_path / "does_not_exist.json")
+        assert key.patients == {} and key.studies == {} and key.series == {}
+
+    def test_merge_folds_in_other_maps(self):
+        a = AnonymizationKey()
+        a.register("MRN1", "s1", "se1")
+        b = AnonymizationKey()
+        b.register("MRN2", "s2", "se2")
+        a.merge(b)
+        assert "MRN1" in a.patients.values()
+        assert "MRN2" in a.patients.values()

--- a/tests/test_create_manifest.py
+++ b/tests/test_create_manifest.py
@@ -68,6 +68,24 @@ class TestCreateManifestBasics:
         series_uid = r.series_instances_dictionary[idx].SeriesInstanceUID
         assert hash_series(series_uid, salt="unit-salt") in df["series_hash"].astype(str).tolist()
 
+    def test_defaults_to_all_rois_when_contour_names_unset(self, synthetic_dataset, tmp_path: Path):
+        # No Contour_Names and no rois= -> record every discovered ROI.
+        r = DicomReaderWriter(description="manifest", verbose=False, require_all_contours=False)
+        r.walk_through_folders(str(synthetic_dataset.walk_root), thread_count=1)
+        assert r.all_rois, "walk should have discovered ROIs"
+        assert not r.Contour_Names
+
+        out = tmp_path / "manifest.csv"
+        r.create_manifest(str(out))
+
+        assert out.exists(), "manifest should be written even without Contour_Names"
+        df = pd.read_csv(out)
+        assert len(df) >= 1
+        roi_cols = [c for c in df.columns if c.endswith(" cc")]
+        assert len(roi_cols) == len(r.all_rois)
+        # At least one real volume was computed (masks were actually rasterised).
+        assert (df[roi_cols] > 0).any().any()
+
     def test_absent_roi_is_negative_one(self, synthetic_dataset, tmp_path: Path):
         r = DicomReaderWriter(
             description="manifest",

--- a/tests/test_create_manifest.py
+++ b/tests/test_create_manifest.py
@@ -1,0 +1,142 @@
+"""Tests for the standalone, incremental metadata manifest (``create_manifest``)."""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+from DicomRTTool import hash_series
+from DicomRTTool.ReaderWriter import DicomReaderWriter
+
+
+def _build_reader(dataset, *, require_all: bool = True) -> DicomReaderWriter:
+    r = DicomReaderWriter(
+        description="manifest",
+        Contour_Names=[p.name for p in dataset.primitives],
+        arg_max=True,
+        verbose=False,
+        require_all_contours=require_all,
+    )
+    r.walk_through_folders(str(dataset.walk_root), thread_count=1)
+    return r
+
+
+class TestCreateManifestBasics:
+    def test_writes_expected_columns_and_no_nifti(self, synthetic_dataset, tmp_path: Path):
+        r = _build_reader(synthetic_dataset)
+        out = tmp_path / "manifest.csv"
+        r.create_manifest(str(out))
+
+        assert out.exists()
+        # No NIfTI files are produced by create_manifest.
+        assert not list(tmp_path.glob("**/*.nii.gz"))
+
+        df = pd.read_csv(out)
+        for col in ["patient_hash", "study_hash", "series_hash",
+                    "PatientID", "StudyInstanceUID", "SeriesInstanceUID",
+                    "spacing_x", "spacing_y", "spacing_z"]:
+            assert col in df.columns
+        # ROI volume columns present and positive for the synthetic primitives.
+        for p in synthetic_dataset.primitives:
+            col = f"{p.name.lower()} cc"
+            assert col in df.columns
+            assert (df[col] > 0).all()
+
+    def test_spacing_matches_image(self, synthetic_dataset, tmp_path: Path):
+        r = _build_reader(synthetic_dataset)
+        idx = r.indexes_with_contours[0]
+        r.set_index(idx)
+        r.get_images()
+        sx, sy, sz = r.dicom_handle.GetSpacing()
+
+        out = tmp_path / "manifest.csv"
+        r.create_manifest(str(out))
+        df = pd.read_csv(out)
+        assert df["spacing_x"].iloc[0] == pytest.approx(sx)
+        assert df["spacing_y"].iloc[0] == pytest.approx(sy)
+        assert df["spacing_z"].iloc[0] == pytest.approx(sz)
+
+    def test_anonymize_omits_raw_identifiers(self, synthetic_dataset, tmp_path: Path):
+        r = _build_reader(synthetic_dataset)
+        out = tmp_path / "manifest.csv"
+        r.create_manifest(str(out), anonymize=True, salt="unit-salt")
+        df = pd.read_csv(out)
+        assert "series_hash" in df.columns
+        assert "PatientID" not in df.columns
+        idx = r.indexes_with_contours[0]
+        series_uid = r.series_instances_dictionary[idx].SeriesInstanceUID
+        assert hash_series(series_uid, salt="unit-salt") in df["series_hash"].astype(str).tolist()
+
+    def test_absent_roi_is_negative_one(self, synthetic_dataset, tmp_path: Path):
+        r = DicomReaderWriter(
+            description="manifest",
+            Contour_Names=[p.name for p in synthetic_dataset.primitives] + ["not_a_real_roi"],
+            arg_max=True,
+            verbose=False,
+            require_all_contours=False,
+        )
+        r.walk_through_folders(str(synthetic_dataset.walk_root), thread_count=1)
+        out = tmp_path / "manifest.csv"
+        r.create_manifest(str(out))
+        df = pd.read_csv(out)
+        assert (df["not_a_real_roi cc"] == -1).all()
+
+
+class TestCreateManifestIncremental:
+    def test_existing_file_is_extended_not_duplicated(
+        self, synthetic_multi_series_dataset, tmp_path: Path,
+    ):
+        # Two independent series under one walk root.
+        names = [p.name for p in synthetic_multi_series_dataset.pairs[0].primitives]
+        r = DicomReaderWriter(
+            description="manifest",
+            Contour_Names=names,
+            arg_max=True,
+            verbose=False,
+        )
+        r.walk_through_folders(str(synthetic_multi_series_dataset.walk_root), thread_count=1)
+        assert len(r.indexes_with_contours) >= 2
+
+        out = tmp_path / "manifest.csv"
+        r.create_manifest(str(out))
+        df_first = pd.read_csv(out)
+        n_first = len(df_first)
+        assert n_first >= 2
+
+        # Re-running on the same data must NOT duplicate any rows.
+        r.create_manifest(str(out))
+        df_again = pd.read_csv(out)
+        assert len(df_again) == n_first
+        assert df_again["SeriesInstanceUID"].is_unique
+
+    def test_append_adds_new_series_and_backfills_columns(self, synthetic_dataset, tmp_path: Path):
+        out = tmp_path / "manifest.csv"
+
+        # Seed the manifest with a pre-existing row for a different series + a
+        # ROI column that the reader does not know about.
+        roi_name = synthetic_dataset.primitives[0].name.lower()
+        seed = pd.DataFrame([{
+            "patient_hash": "Pseed", "study_hash": "STseed", "series_hash": "SEseed",
+            "PatientID": "SEED", "StudyInstanceUID": "seed.study",
+            "SeriesInstanceUID": "seed.series",
+            "spacing_x": 1.0, "spacing_y": 1.0, "spacing_z": 1.0,
+            "legacy_roi cc": 12.5,
+        }])
+        seed.to_csv(out, index=False)
+
+        r = _build_reader(synthetic_dataset)
+        r.create_manifest(str(out))
+        df = pd.read_csv(out)
+
+        # Seed row preserved, plus the newly walked series appended.
+        assert "seed.series" in df["SeriesInstanceUID"].astype(str).tolist()
+        assert len(df) >= 2
+        # New ROI columns added; the seed row gets -1 for them.
+        assert f"{roi_name} cc" in df.columns
+        seed_row = df[df["SeriesInstanceUID"] == "seed.series"]
+        assert (seed_row[f"{roi_name} cc"] == -1).all()
+        # The legacy column is preserved; new rows are backfilled to -1.
+        assert "legacy_roi cc" in df.columns
+        new_rows = df[df["SeriesInstanceUID"] != "seed.series"]
+        assert (new_rows["legacy_roi cc"] == -1).all()

--- a/tests/test_csharp_parity.py
+++ b/tests/test_csharp_parity.py
@@ -1,0 +1,66 @@
+"""Opt-in parity test: DicomRTTool (Python) vs the C# DicomRtNifti.Cli tool.
+
+This test is **skipped** unless both environment variables are set, so the
+normal hermetic suite (and CI) never needs the external LCTSC corpus or the
+built C# binary:
+
+* ``DICOMRTTOOL_LCTSC_DIR`` — path to the LCTSC patient-root directory
+  (``.../datasets/v2/lctsc``);
+* ``DICOMRTTOOL_CSHARP_EXE`` — path to ``DicomRtNifti.Cli.exe``.
+
+Optional: ``DICOMRTTOOL_PARITY_N`` (patient count, default 2).
+
+The thresholds are intentionally tolerant: the two tools use different
+polygon-boundary conventions, so masks agree closely but are not identical.
+"""
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+LCTSC_DIR = os.environ.get("DICOMRTTOOL_LCTSC_DIR")
+CSHARP_EXE = os.environ.get("DICOMRTTOOL_CSHARP_EXE")
+
+pytestmark = pytest.mark.skipif(
+    not (LCTSC_DIR and CSHARP_EXE and Path(LCTSC_DIR).is_dir() and Path(CSHARP_EXE).is_file()),
+    reason="Set DICOMRTTOOL_LCTSC_DIR and DICOMRTTOOL_CSHARP_EXE to run the C# parity test.",
+)
+
+
+@pytest.fixture(scope="module")
+def parity_result(tmp_path_factory):
+    from evaluation.csharp_eval import evaluate
+
+    n = int(os.environ.get("DICOMRTTOOL_PARITY_N", "2"))
+    work = tmp_path_factory.mktemp("csharp_parity")
+    return evaluate(
+        dataset_dir=LCTSC_DIR,
+        csharp_exe=CSHARP_EXE,
+        work_dir=str(work),
+        num_patients=n,
+        target_spacing=(3.0, 3.0, 3.0),
+    )
+
+
+def test_masks_agree_within_boundary_tolerance(parity_result):
+    assert parity_result.mask_rows, "no mask comparisons were produced"
+    dices = [r["dice"] for r in parity_result.mask_rows]
+    # Boundary-convention differences keep this below 1.0 but well above 0.9
+    # for these large thoracic OARs.
+    assert np.median(dices) > 0.95, f"median Dice too low: {np.median(dices):.4f}"
+    assert np.min(dices) > 0.80, f"a mask diverged badly: min Dice {np.min(dices):.4f}"
+
+
+def test_native_images_match_closely(parity_result):
+    assert parity_result.image_rows, "no image comparisons were produced"
+    # Both tools read the same DICOM via SimpleITK -> near-identical voxels.
+    assert max(r["mean_abs_error"] for r in parity_result.image_rows) < 1.0
+
+
+def test_resample_parity(parity_result):
+    assert parity_result.resample_rows, "no resample comparisons were produced"
+    # Both resample the same image to the same spacing with linear interp.
+    assert max(r["mean_abs_error"] for r in parity_result.resample_rows) < 5.0

--- a/tests/test_mask_rasterization.py
+++ b/tests/test_mask_rasterization.py
@@ -1,0 +1,61 @@
+"""Rasterisation correctness: parallel path must match the serial path."""
+from __future__ import annotations
+
+import numpy as np
+import pytest
+import SimpleITK as sitk
+
+from DicomRTTool.ReaderWriter import DicomReaderWriter, _mask_threads_for
+
+
+def _load(dataset, mask_thread_count: int) -> DicomReaderWriter:
+    r = DicomReaderWriter(
+        description="raster",
+        Contour_Names=[p.name for p in dataset.primitives],
+        arg_max=True,
+        verbose=False,
+        mask_thread_count=mask_thread_count,
+    )
+    r.walk_through_folders(str(dataset.walk_root), thread_count=1)
+    r.set_index(r.indexes_with_contours[0])
+    r.get_images_and_mask()
+    return r
+
+
+class TestParallelMatchesSerial:
+    def test_combined_mask_identical(self, synthetic_dataset):
+        serial = _load(synthetic_dataset, 1)
+        parallel = _load(synthetic_dataset, 4)
+        assert np.array_equal(serial.mask, parallel.mask)
+
+    def test_per_roi_handles_identical(self, synthetic_dataset):
+        serial = _load(synthetic_dataset, 1)
+        parallel = _load(synthetic_dataset, 4)
+        assert set(serial.mask_dictionary) == set(parallel.mask_dictionary)
+        for name in serial.mask_dictionary:
+            a = sitk.GetArrayFromImage(serial.mask_dictionary[name])
+            b = sitk.GetArrayFromImage(parallel.mask_dictionary[name])
+            assert np.array_equal(a, b), f"mask for {name} differs between serial/parallel"
+
+    def test_volumes_identical(self, synthetic_dataset):
+        serial = _load(synthetic_dataset, 1)
+        parallel = _load(synthetic_dataset, 4)
+        vs = serial.series_instances_dictionary[serial.index].additional_tags["Volumes"]
+        vp = parallel.series_instances_dictionary[parallel.index].additional_tags["Volumes"]
+        assert np.array_equal(vs, vp)
+
+
+class TestMaskThreadSplit:
+    @pytest.mark.parametrize(
+        "workers,n_series,expected",
+        [
+            (9, 1, 4),    # single series -> use spare cores, capped at 4
+            (9, 10, 1),   # more series than cores -> serial masks
+            (8, 2, 4),    # 8 // 2 == 4
+            (9, 3, 3),    # 9 // 3 == 3
+            (9, 0, 1),    # guard against div-by-zero
+            (1, 1, 1),    # no spare cores
+        ],
+    )
+    def test_split(self, workers, n_series, expected):
+        assert _mask_threads_for(workers, n_series) == expected

--- a/tests/test_nifti_export.py
+++ b/tests/test_nifti_export.py
@@ -71,6 +71,20 @@ class TestWriteImagesAnnotations:
         assert target.is_dir()
         assert any(target.glob("Overall_Data_*.nii.gz"))
 
+    def test_output_spacing_resamples_image_and_mask(
+        self, reader_with_mask: DicomReaderWriter, tmp_path: Path,
+    ):
+        target = (4.0, 4.0, 4.0)
+        reader_with_mask.write_images_annotations(str(tmp_path), output_spacing=target)
+        img = sitk.ReadImage(str(next(tmp_path.glob("Overall_Data_*.nii.gz"))))
+        mask = sitk.ReadImage(str(next(tmp_path.glob("Overall_mask_*.nii.gz"))))
+        assert img.GetSpacing() == pytest.approx(target)
+        assert mask.GetSpacing() == pytest.approx(target)
+        assert img.GetSize() == mask.GetSize()
+        # Nearest-neighbour keeps the mask integer-labelled (no blended values).
+        labels = np.unique(sitk.GetArrayFromImage(mask))
+        assert np.all(labels == labels.astype(np.int32))
+
 
 class TestWriteParallel:
     """Smoke test for the bulk-export entry point."""

--- a/tests/test_per_roi_export.py
+++ b/tests/test_per_roi_export.py
@@ -132,3 +132,22 @@ class TestWritePerRoiWithDose:
         case = next(p for p in out.iterdir() if p.is_dir())
         doses = list((case / "doses").glob("*.nii.gz")) if (case / "doses").exists() else []
         assert doses, "expected a dose NIfTI in doses/"
+
+    def test_resampled_dose_shares_image_and_mask_grid(
+        self, synthetic_dataset_with_dose, tmp_path: Path,
+    ):
+        r = _build_reader(synthetic_dataset_with_dose, with_dose=True)
+        out = tmp_path / "out"
+        r.write_per_roi(str(out), output_spacing=(1.5, 2.5, 3.5))
+        case = next(p for p in out.iterdir() if p.is_dir())
+
+        image = sitk.ReadImage(str(case / "image.nii.gz"))
+        dose = sitk.ReadImage(str(next((case / "doses").glob("*.nii.gz"))))
+        mask = sitk.ReadImage(str(next((case / "masks").glob("*.nii.gz"))))
+
+        # Dose, image, and mask must be voxel-aligned on one grid.
+        for other in (dose, mask):
+            assert other.GetSize() == image.GetSize()
+            assert other.GetSpacing() == pytest.approx(image.GetSpacing())
+            assert other.GetOrigin() == pytest.approx(image.GetOrigin())
+            assert other.GetDirection() == pytest.approx(image.GetDirection())

--- a/tests/test_per_roi_export.py
+++ b/tests/test_per_roi_export.py
@@ -1,0 +1,134 @@
+"""Tests for the C#-compatible per-ROI NIfTI export (``write_per_roi``)."""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pandas as pd
+import pytest
+import SimpleITK as sitk
+
+from DicomRTTool import hash_series
+from DicomRTTool.ReaderWriter import DicomReaderWriter
+
+
+def _build_reader(dataset, *, with_dose: bool = False) -> DicomReaderWriter:
+    r = DicomReaderWriter(
+        description="per-roi",
+        Contour_Names=[p.name for p in dataset.primitives],
+        arg_max=True,
+        verbose=False,
+        get_dose_output=with_dose,
+    )
+    r.walk_through_folders(str(dataset.walk_root), thread_count=1)
+    return r
+
+
+class TestWritePerRoiLayout:
+    @pytest.mark.parametrize("thread_count", [1, 2])
+    def test_writes_image_masks_and_manifest(
+        self, synthetic_dataset, tmp_path: Path, thread_count: int,
+    ):
+        r = _build_reader(synthetic_dataset)
+        out = tmp_path / f"out_t{thread_count}"
+        r.write_per_roi(str(out), thread_count=thread_count)
+
+        manifest = out / "manifest.csv"
+        assert manifest.exists()
+
+        case_dirs = [p for p in out.iterdir() if p.is_dir()]
+        assert case_dirs, "no case folder produced"
+        case = case_dirs[0]
+        assert (case / "image.nii.gz").exists()
+        masks = list((case / "masks").glob("*.nii.gz"))
+        roi_names = {p.name.lower() for p in synthetic_dataset.primitives}
+        assert {m.stem.replace(".nii", "").lower() for m in masks} == roi_names
+
+    def test_manifest_columns_and_volumes(self, synthetic_dataset, tmp_path: Path):
+        r = _build_reader(synthetic_dataset)
+        out = tmp_path / "out"
+        r.write_per_roi(str(out))
+
+        df = pd.read_csv(out / "manifest.csv")
+        for col in ["case_id", "patient_hash", "study_hash", "series_hash",
+                    "spacing_x", "spacing_y", "spacing_z"]:
+            assert col in df.columns
+        # one ``<roi> cc`` column per contour, all present here -> volume > 0.
+        for p in synthetic_dataset.primitives:
+            col = f"{p.name.lower()} cc"
+            assert col in df.columns
+            assert (df[col] > 0).all()
+
+    def test_absent_roi_is_negative_one(self, synthetic_dataset, tmp_path: Path):
+        # Ask for an ROI that does not exist -> its column should be -1.
+        # require_all_contours=False so the series is still indexed despite the
+        # missing ROI (this is the union-of-ROIs manifest case).
+        r = DicomReaderWriter(
+            description="per-roi",
+            Contour_Names=[p.name for p in synthetic_dataset.primitives] + ["not_a_real_roi"],
+            arg_max=True,
+            verbose=False,
+            require_all_contours=False,
+        )
+        r.walk_through_folders(str(synthetic_dataset.walk_root), thread_count=1)
+        out = tmp_path / "out"
+        r.write_per_roi(str(out))
+
+        df = pd.read_csv(out / "manifest.csv")
+        assert (df["not_a_real_roi cc"] == -1).all()
+
+    def test_no_masks_subfolder_when_dose_absent(self, synthetic_dataset, tmp_path: Path):
+        r = _build_reader(synthetic_dataset)
+        out = tmp_path / "out"
+        r.write_per_roi(str(out))
+        case = next(p for p in out.iterdir() if p.is_dir())
+        assert not (case / "doses").exists()
+
+
+class TestWritePerRoiAnonymize:
+    def test_folder_named_by_series_hash_and_key_file_written(
+        self, synthetic_dataset, tmp_path: Path,
+    ):
+        r = _build_reader(synthetic_dataset)
+        out = tmp_path / "out"
+        r.write_per_roi(str(out), anonymize=True, salt="unit-test-salt")
+
+        idx = r.indexes_with_contours[0]
+        series_uid = r.series_instances_dictionary[idx].SeriesInstanceUID
+        expected = hash_series(series_uid, salt="unit-test-salt")
+        assert (out / expected).is_dir()
+        assert (out / "anonymization_key.json").exists()
+
+        # Manifest should carry hashes but not raw identifiers.
+        df = pd.read_csv(out / "manifest.csv")
+        assert "series_hash" in df.columns
+        assert "PatientID" not in df.columns
+
+
+class TestWritePerRoiResample:
+    def test_image_and_mask_resampled_to_spacing(self, synthetic_dataset, tmp_path: Path):
+        r = _build_reader(synthetic_dataset)
+        out = tmp_path / "out"
+        target = (3.0, 3.0, 3.0)
+        r.write_per_roi(str(out), output_spacing=target)
+
+        case = next(p for p in out.iterdir() if p.is_dir())
+        img = sitk.ReadImage(str(case / "image.nii.gz"))
+        assert img.GetSpacing() == pytest.approx(target)
+
+        mask = next((case / "masks").glob("*.nii.gz"))
+        m = sitk.ReadImage(str(mask))
+        assert m.GetSpacing() == pytest.approx(target)
+        assert m.GetSize() == img.GetSize()
+
+        df = pd.read_csv(out / "manifest.csv")
+        assert df["spacing_x"].iloc[0] == pytest.approx(3.0)
+
+
+class TestWritePerRoiWithDose:
+    def test_dose_subfolder_written(self, synthetic_dataset_with_dose, tmp_path: Path):
+        r = _build_reader(synthetic_dataset_with_dose, with_dose=True)
+        out = tmp_path / "out"
+        r.write_per_roi(str(out))
+        case = next(p for p in out.iterdir() if p.is_dir())
+        doses = list((case / "doses").glob("*.nii.gz")) if (case / "doses").exists() else []
+        assert doses, "expected a dose NIfTI in doses/"

--- a/tests/test_resample.py
+++ b/tests/test_resample.py
@@ -1,0 +1,82 @@
+"""Tests for the spacing-tuple resampler ``resample_to_spacing``."""
+from __future__ import annotations
+
+import numpy as np
+import pytest
+import SimpleITK as sitk
+
+from DicomRTTool import resample_to_spacing
+
+
+def _make_image(
+    size=(20, 16, 10),          # (x, y, z)
+    spacing=(1.0, 1.0, 2.0),
+    origin=(3.0, -5.0, 7.0),
+    binary=False,
+) -> sitk.Image:
+    # numpy array is (z, y, x).
+    arr = np.zeros((size[2], size[1], size[0]), dtype=np.float32)
+    if binary:
+        arr[2:6, 4:10, 5:15] = 1
+    img = sitk.GetImageFromArray(arr)
+    img.SetSpacing(spacing)
+    img.SetOrigin(origin)
+    return img
+
+
+class TestResampleSizeMath:
+    def test_new_size_is_ceil_of_physical_extent(self):
+        img = _make_image()
+        out = resample_to_spacing(img, (2.0, 2.0, 2.0), "Linear")
+        # x: ceil(20*1/2)=10, y: ceil(16*1/2)=8, z: ceil(10*2/2)=10
+        assert out.GetSize() == (10, 8, 10)
+
+    def test_upsample_size(self):
+        img = _make_image(size=(10, 10, 5), spacing=(2.0, 2.0, 2.0))
+        out = resample_to_spacing(img, (1.0, 1.0, 1.0))
+        assert out.GetSize() == (20, 20, 10)
+
+    def test_degenerate_axis_clamped_to_one(self):
+        img = _make_image()
+        out = resample_to_spacing(img, (1000.0, 1000.0, 1000.0))
+        assert out.GetSize() == (1, 1, 1)
+
+    def test_output_spacing_applied(self):
+        img = _make_image()
+        out = resample_to_spacing(img, (2.5, 2.5, 3.0))
+        assert out.GetSpacing() == pytest.approx((2.5, 2.5, 3.0))
+
+
+class TestResampleGeometryPreserved:
+    def test_origin_and_direction_preserved(self):
+        img = _make_image()
+        out = resample_to_spacing(img, (2.0, 2.0, 2.0))
+        assert out.GetOrigin() == pytest.approx(img.GetOrigin())
+        assert out.GetDirection() == pytest.approx(img.GetDirection())
+
+
+class TestInterpolatorBehaviour:
+    def test_nearest_keeps_mask_binary(self):
+        img = _make_image(binary=True)
+        out = resample_to_spacing(img, (0.7, 0.7, 1.3), "Nearest")
+        values = set(np.unique(sitk.GetArrayFromImage(out)).tolist())
+        assert values.issubset({0.0, 1.0})
+
+    def test_linear_may_blend(self):
+        # Linear interpolation of a binary edge can produce intermediate values.
+        img = _make_image(binary=True)
+        out = resample_to_spacing(img, (0.5, 0.5, 0.9), "Linear")
+        arr = sitk.GetArrayFromImage(out)
+        assert arr.max() <= 1.0 + 1e-6
+
+    def test_unknown_interpolator_raises(self):
+        img = _make_image()
+        with pytest.raises(ValueError):
+            resample_to_spacing(img, (2.0, 2.0, 2.0), "Cubic")
+
+    def test_bad_spacing_raises(self):
+        img = _make_image()
+        with pytest.raises(ValueError):
+            resample_to_spacing(img, (2.0, -1.0, 2.0))
+        with pytest.raises(ValueError):
+            resample_to_spacing(img, (2.0, 2.0))  # type: ignore[arg-type]

--- a/tests/test_resample.py
+++ b/tests/test_resample.py
@@ -5,7 +5,7 @@ import numpy as np
 import pytest
 import SimpleITK as sitk
 
-from DicomRTTool import resample_to_spacing
+from DicomRTTool import resample_to_reference, resample_to_spacing
 
 
 def _make_image(
@@ -80,3 +80,26 @@ class TestInterpolatorBehaviour:
             resample_to_spacing(img, (2.0, -1.0, 2.0))
         with pytest.raises(ValueError):
             resample_to_spacing(img, (2.0, 2.0))  # type: ignore[arg-type]
+
+
+class TestResampleToReference:
+    def test_output_matches_reference_grid(self):
+        moving = _make_image(size=(40, 40, 20), spacing=(0.5, 0.5, 1.0))
+        reference = _make_image(size=(20, 16, 10), spacing=(1.0, 2.0, 3.0), origin=(1.0, 2.0, 3.0))
+        out = resample_to_reference(moving, reference, "Linear")
+        assert out.GetSize() == reference.GetSize()
+        assert out.GetSpacing() == pytest.approx(reference.GetSpacing())
+        assert out.GetOrigin() == pytest.approx(reference.GetOrigin())
+        assert out.GetDirection() == pytest.approx(reference.GetDirection())
+
+    def test_nearest_keeps_mask_binary(self):
+        moving = _make_image(binary=True)
+        reference = _make_image(size=(15, 12, 8), spacing=(1.3, 1.4, 1.5))
+        out = resample_to_reference(moving, reference, "Nearest")
+        values = set(np.unique(sitk.GetArrayFromImage(out)).tolist())
+        assert values.issubset({0.0, 1.0})
+
+    def test_unknown_interpolator_raises(self):
+        img = _make_image()
+        with pytest.raises(ValueError):
+            resample_to_reference(img, img, "Cubic")


### PR DESCRIPTION
## Summary

Ports the DICOM→NIfTI feature set from the companion C# `DicomRtNifti` tool into the Python package. All additions are **backward compatible** — existing APIs (`write_images_annotations`, `write_parallel`, `characterize_data_to_csv`) are unchanged.

## What's new

- **`DicomReaderWriter.write_per_roi(...)`** — bulk export to a per-ROI layout matching the C# tool: `<case>/image.nii.gz`, `<case>/masks/<roi>.nii.gz`, `<case>/doses/<desc>.nii.gz`, plus a single `manifest.csv` (patient/study/series ids, output spacing, per-ROI volume in cc; `-1` for ROIs absent from a series). No persistent iteration index.
- **Output resampling** — optional `output_spacing` on `write_per_roi` and `write_images_annotations`, plus a public `resample_to_spacing(handle, spacing, interpolator)` helper. Linear for image/dose, nearest-neighbour for masks (labels never blended). Mirrors the C# `ResampleToSpacing` size math.
- **Anonymization** — deterministic SHA-256 hashing matching the C# `AnonymizationService` byte-for-byte: `hash_patient` (`P`/5 bytes), `hash_study` (`ST`/6), `hash_series` (`SE`/6), `deterministic_hash_string`, and an `AnonymizationKey` JSON load/save. With `anonymize=True` the manifest carries only hashes, case folders are named by the series hash, and an `anonymization_key.json` reverse-lookup file is written.
- **Cross-tool evaluation harness** under [`evaluation/`](evaluation/README.md) — runs DicomRTTool and the C# binary live on TCIA LCTSC and compares mask generation (Dice/volume), image generation (voxel MAE/geometry), and the resample feature.

## Testing

- New hermetic unit tests: `test_anonymizer.py`, `test_resample.py`, `test_per_roi_export.py`, plus an `output_spacing` case in `test_nifti_export.py`. **126 passed, 3 skipped**, ruff clean.
- `tests/test_csharp_parity.py` is **opt-in** and auto-skips unless `DICOMRTTOOL_LCTSC_DIR` and `DICOMRTTOOL_CSHARP_EXE` are set, so CI stays hermetic.

### Live 10-patient LCTSC comparison vs the C# tool

| Comparison | Result |
|---|---|
| Masks (Dice, 50 ROIs) | mean 0.96, median 0.99 — close, not identical (C# fills polygon interior; this tool is boundary-inclusive) |
| Native image generation | MAE **0.0** across all 10 |
| Resample parity (3×3×3 mm) | MAE ~0.40 HU; identical output sizes |

## Docs

Updated README, CHANGELOG (`[Unreleased]`), added `evaluation/README.md`, and fixed pre-existing stale `excel_file=`/`.xlsx` references in the tutorial notebook (now `index_file=`/`.csv`).

## Notes

- `write_parallel`'s index-based path is kept intact for backward compatibility; `write_per_roi` is the new index-free path.
- Version in `pyproject.toml` is **not** bumped (CHANGELOG uses `[Unreleased]`) — a maintainer can bump at release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)